### PR TITLE
Use html/template instead of text/template

### DIFF
--- a/handlers/views.go
+++ b/handlers/views.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"fmt"
+	"html/template"
 	"log"
 	"net/http"
 	"path"
-	"text/template"
 	"time"
 
 	"github.com/mtlynch/picoshare/v2/types"


### PR DESCRIPTION
html/template does proper escaping of values