### PR TITLE
Change tests to use SQLite in-memory with a shared cache

### DIFF
--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -98,6 +98,7 @@ func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
 		t.Fatalf("retrieving datastore metadata failed: %v", err)
 	}
 
+	// Sort the elements so they have a consistent ordering.
 	sort.Slice(remaining, func(i, j int) bool {
 		return (time.Time(remaining[i].Expires)).After(time.Time(remaining[j].Expires))
 	})

--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDeleteExistingFile(t *testing.T) {
-	dataStore := sqlite.New(":memory:")
+	dataStore := sqlite.New("file::memory:?cache=shared")
 	dataStore.InsertEntry(makeData("dummy data"),
 		types.UploadMetadata{
 			ID: types.EntryID("hR87apiUCjTV9E"),
@@ -42,7 +42,7 @@ func TestDeleteExistingFile(t *testing.T) {
 }
 
 func TestDeleteNonExistentFile(t *testing.T) {
-	dataStore := sqlite.New(":memory:")
+	dataStore := sqlite.New("file::memory:?cache=shared")
 
 	s := handlers.New(mockAuthenticator{}, dataStore)
 
@@ -62,7 +62,7 @@ func TestDeleteNonExistentFile(t *testing.T) {
 }
 
 func TestDeleteInvalidEntryID(t *testing.T) {
-	dataStore := sqlite.New(":memory:")
+	dataStore := sqlite.New("file::memory:?cache=shared")
 
 	s := handlers.New(mockAuthenticator{}, dataStore)
 

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -30,7 +30,7 @@ func (ma mockAuthenticator) Authenticate(r *http.Request) bool {
 }
 
 func TestUploadValidFile(t *testing.T) {
-	store := sqlite.New(":memory:")
+	store := sqlite.New("file::memory:?cache=shared")
 	s := handlers.New(mockAuthenticator{}, store)
 
 	filename := "dummyimage.png"
@@ -129,7 +129,7 @@ func TestEntryPostRejectsInvalidRequest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		store := sqlite.New(":memory:")
+		store := sqlite.New("file::memory:?cache=shared")
 		s := handlers.New(mockAuthenticator{}, store)
 
 		formData, contentType := createMultipartFormBody(tt.name, tt.filename, bytes.NewBuffer([]byte(tt.contents)))


### PR DESCRIPTION
There's a race condition documented in the mattn/gosqlite driver where multiple clients of the DB pool can get separate copies of the database and have distinct views. Using a shared cache works around this issue.