### PR TITLE
Simplify garbage collection tests

### DIFF
--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -39,13 +39,11 @@ func TestCollectExpiredFile(t *testing.T) {
 		types.UploadMetadata{
 			ID:      types.EntryID("AAAAAAAAAAAA"),
 			Expires: mustParseExpirationTime("2000-01-01T00:00:00Z"),
-			Size:    len(d),
 		})
 	dataStore.InsertEntry(makeData(d),
 		types.UploadMetadata{
 			ID:      types.EntryID("BBBBBBBBBBBB"),
 			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    len(d),
 		})
 
 	c := garbagecollect.NewCollector(dataStore)
@@ -78,13 +76,11 @@ func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
 		types.UploadMetadata{
 			ID:      types.EntryID("AAAAAAAAAAAA"),
 			Expires: mustParseExpirationTime("4000-01-01T00:00:00Z"),
-			Size:    len(d),
 		})
 	dataStore.InsertEntry(makeData(d),
 		types.UploadMetadata{
 			ID:      types.EntryID("BBBBBBBBBBBB"),
 			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    len(d),
 		})
 
 	c := garbagecollect.NewCollector(dataStore)


### PR DESCRIPTION
The entry insertion doesn't actually read the size property of the metadata, so we can omit it when we insert data for the test.