### PR TITLE
Add function for creating SQLite test DBs

### DIFF
--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/mtlynch/picoshare/v2/garbagecollect"
-	"github.com/mtlynch/picoshare/v2/store/sqlite"
+	"github.com/mtlynch/picoshare/v2/store/sqlite_test"
 	"github.com/mtlynch/picoshare/v2/types"
 )
 
 func TestCollectDoesNothingWhenStoreIsEmpty(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 	c := garbagecollect.NewCollector(dataStore)
 	err := c.Collect()
 	if err != nil {
@@ -33,7 +33,7 @@ func TestCollectDoesNothingWhenStoreIsEmpty(t *testing.T) {
 }
 
 func TestCollectExpiredFile(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 	d := "dummy data"
 	dataStore.InsertEntry(makeData(d),
 		types.UploadMetadata{
@@ -70,7 +70,7 @@ func TestCollectExpiredFile(t *testing.T) {
 }
 
 func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 	d := "dummy data"
 	dataStore.InsertEntry(makeData(d),
 		types.UploadMetadata{

--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/mtlynch/picoshare/v2/handlers"
 	"github.com/mtlynch/picoshare/v2/store"
-	"github.com/mtlynch/picoshare/v2/store/sqlite"
+	"github.com/mtlynch/picoshare/v2/store/sqlite_test"
 	"github.com/mtlynch/picoshare/v2/types"
 )
 
 func TestDeleteExistingFile(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 	dataStore.InsertEntry(makeData("dummy data"),
 		types.UploadMetadata{
 			ID: types.EntryID("hR87apiUCjTV9E"),
@@ -42,7 +42,7 @@ func TestDeleteExistingFile(t *testing.T) {
 }
 
 func TestDeleteNonExistentFile(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 
 	s := handlers.New(mockAuthenticator{}, dataStore)
 
@@ -62,7 +62,7 @@ func TestDeleteNonExistentFile(t *testing.T) {
 }
 
 func TestDeleteInvalidEntryID(t *testing.T) {
-	dataStore := sqlite.New("file::memory:?cache=shared")
+	dataStore := sqlite_test.New()
 
 	s := handlers.New(mockAuthenticator{}, dataStore)
 

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/mtlynch/picoshare/v2/handlers"
-	"github.com/mtlynch/picoshare/v2/store/sqlite"
+	"github.com/mtlynch/picoshare/v2/store/sqlite_test"
 	"github.com/mtlynch/picoshare/v2/types"
 )
 
@@ -30,7 +30,7 @@ func (ma mockAuthenticator) Authenticate(r *http.Request) bool {
 }
 
 func TestUploadValidFile(t *testing.T) {
-	store := sqlite.New("file::memory:?cache=shared")
+	store := sqlite_test.New()
 	s := handlers.New(mockAuthenticator{}, store)
 
 	filename := "dummyimage.png"
@@ -129,7 +129,7 @@ func TestEntryPostRejectsInvalidRequest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		store := sqlite.New("file::memory:?cache=shared")
+		store := sqlite_test.New()
 		s := handlers.New(mockAuthenticator{}, store)
 
 		formData, contentType := createMultipartFormBody(tt.name, tt.filename, bytes.NewBuffer([]byte(tt.contents)))

--- a/store/sqlite_test/db.go
+++ b/store/sqlite_test/db.go
@@ -1,0 +1,15 @@
+package sqlite_test
+
+import (
+	"fmt"
+
+	"github.com/mtlynch/picoshare/v2/random"
+	"github.com/mtlynch/picoshare/v2/store"
+	"github.com/mtlynch/picoshare/v2/store/sqlite"
+)
+
+func New() store.Store {
+	name := random.String(10, []rune("abcdefghijklmnopqrstuvwxyz0123456789"))
+
+	return sqlite.New(fmt.Sprintf("file:%s?mode=memory&cache=shared", name))
+}


### PR DESCRIPTION
If unit tests all use the :memory: special name, the DB can persist across tests and taint results between tests. This ensures that each test case gets a unique database.