### PR TITLE
Fix fly volumes create command

### DIFF
--- a/docs/fly.io.md
+++ b/docs/fly.io.md
@@ -23,8 +23,7 @@ SIZE_IN_GB=3 # This is the limit of fly.io's free tier as of 2022-02-19
 REGION="iad"
 
 fly volumes create "${VOLUME_NAME}" \
-  --encrypted \
-  --region="${REGION}" \
+  --region "${REGION}" \
   --size "${SIZE_IN_GB}"
 ```
 


### PR DESCRIPTION
They've changed the behavior so that encryption is default, so the --encrypted flag no longer works