### PR TITLE
Remove sqlite checks for expiration

### DIFF
--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -111,10 +111,7 @@ func (d db) GetEntry(id types.EntryID) (types.UploadEntry, error) {
 		FROM
 			entries
 		WHERE
-			id=? AND
-			-- TODO: Purge expired records instead of filtering them here.
-			expiration_time >= strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
-			`)
+			id=?`)
 	if err != nil {
 		return types.UploadEntry{}, err
 	}


### PR DESCRIPTION
As of 417c03056ec47a7a1a9f60428bbbf393bb15f81e, the garbage collector purges expired files, so we don't have to check the expiration time in SQLite.