### PR TITLE
Adds a "never" expiration by utilizing 'null' FE and zero time BE

### DIFF
--- a/garbagecollect/collect.go
+++ b/garbagecollect/collect.go
@@ -24,6 +24,10 @@ func (c Collector) Collect() error {
 	}
 
 	for _, meta := range mm {
+		// "zero" expiration dates are treated as "never" expire so they should not be GCd.
+		if time.Time(meta.Expires).IsZero() {
+			continue
+		}
 		if time.Now().After(time.Time(meta.Expires)) {
 			log.Printf("entry %v expired at %v", meta.ID, time.Time(meta.Expires).Format(time.RFC3339))
 			if err := c.store.DeleteEntry(meta.ID); err != nil {

--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -48,7 +48,7 @@ func TestCollectExpiredFile(t *testing.T) {
 	dataStore.InsertEntry(makeData(d),
 		types.UploadMetadata{
 			ID:      types.EntryID("CCCCCCCCCCCC"),
-			Expires: types.ExpirationTime(*new(time.Time)),  // "zero" time should be treated as never
+			Expires: types.ExpirationTime(*new(time.Time)), // "zero" time should be treated as never
 		})
 
 	c := garbagecollect.NewCollector(dataStore)

--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -79,53 +79,6 @@ func TestCollectExpiredFile(t *testing.T) {
 	}
 }
 
-func TestCollectExpiredFileSkipsFilesWithZeroExpiration(t *testing.T) {
-	dataStore := test_sqlite.New()
-	d := "dummy data"
-	dataStore.InsertEntry(makeData(d),
-		types.UploadMetadata{
-			ID:      types.EntryID("AAAAAAAAAAAA"),
-			Expires: mustParseExpirationTime("2000-01-01T00:00:00Z"),
-		})
-	dataStore.InsertEntry(makeData(d),
-		types.UploadMetadata{
-			ID:      types.EntryID("BBBBBBBBBBBB"),
-			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-		})
-	dataStore.InsertEntry(makeData(d),
-		types.UploadMetadata{
-			ID:      types.EntryID("CCCCCCCCCCCC"),
-			Expires: types.ExpirationTime(*new(time.Time)),
-		})
-
-	c := garbagecollect.NewCollector(dataStore)
-	err := c.Collect()
-	if err != nil {
-		t.Fatalf("garbage collection failed: %v", err)
-	}
-
-	remaining, err := dataStore.GetEntriesMetadata()
-	if err != nil {
-		t.Fatalf("retrieving datastore metadata failed: %v", err)
-	}
-
-	expected := []types.UploadMetadata{
-		{
-			ID:      types.EntryID("BBBBBBBBBBBB"),
-			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    len(d),
-		},
-		{
-			ID:      types.EntryID("CCCCCCCCCCCC"),
-			Expires: types.ExpirationTime(*new(time.Time)),
-			Size:    len(d),
-		},
-	}
-	if !reflect.DeepEqual(expected, remaining) {
-		t.Fatalf("unexpected results in datastore: got %v, want %v", remaining, expected)
-	}
-}
-
 func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
 	dataStore := test_sqlite.New()
 	d := "dummy data"

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -153,6 +153,13 @@ func parseExpiration(r *http.Request) (types.ExpirationTime, error) {
 	if len(expirationRaw) <= 0 {
 		return types.ExpirationTime{}, errors.New("missing required URL parameter: expiration")
 	}
+
+	// null expiration is treated as "never expire".
+	// Short circuit additional checks, returning "zero" time
+	if expirationRaw[0] == "null" {
+		return types.ExpirationTime(*new(time.Time)), nil
+	}
+
 	expiration, err := time.Parse(time.RFC3339, expirationRaw[0])
 	if err != nil {
 		log.Printf("invalid expiration URL parameter: %v -> %v", expirationRaw, err)

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -117,7 +117,6 @@ func TestUploadValidFileWithNullExpiration(t *testing.T) {
 	}
 }
 
-
 func TestEntryPostRejectsInvalidRequest(t *testing.T) {
 	tests := []struct {
 		description string

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -60,6 +60,11 @@ func (s Server) fileIndexGet() http.HandlerFunc {
 			},
 			"formatExpiration": func(et types.ExpirationTime) string {
 				t := time.Time(et)
+				// zero time is interpreted as "never"
+				// return a meaningful expiration string instead of -XXXX years
+				if t.IsZero() {
+					return "N/A"
+				}
 				delta := time.Until(t)
 				return fmt.Sprintf("%s (%.0f days)", t.Format(time.RFC3339), delta.Hours()/24)
 			},

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -29,7 +29,7 @@ function populateExpirationOptions() {
     "7 days": dateInFuture(7),
     "30 days": dateInFuture(30),
     "1 year": dateInFuture(365),
-    "Never": null,
+    Never: null,
   };
   const defaultExpiration = "30 days";
   for (const [k, v] of Object.entries(expirationTimes)) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -29,12 +29,13 @@ function populateExpirationOptions() {
     "7 days": dateInFuture(7),
     "30 days": dateInFuture(30),
     "1 year": dateInFuture(365),
+    "Never": null,
   };
   const defaultExpiration = "30 days";
   for (const [k, v] of Object.entries(expirationTimes)) {
     const selectOption = document.createElement("option");
     selectOption.innerText = k;
-    selectOption.value = v.toISOString();
+    selectOption.value = v ? v.toISOString() : null;
     if (k === defaultExpiration) {
       selectOption.selected = true;
     }


### PR DESCRIPTION
This solves https://github.com/mtlynch/picoshare/issues/92 by adding a "never" expire option, utilizing Go's "zero" time as a token treated as "never".

I have considered using `nil` instead, but the changes seemed uglier. 
This solution could potentially be improved by implementing "Never" as a native `types.ExpirationTime` context rather than using `types.ExpirationTime` of time zero. 


![image](https://user-images.githubusercontent.com/9766351/159808431-17e9c60e-030a-47dd-a5b1-ae7e4f3283fa.png)
