### PR TITLE
Fix sym-link for Apple

### DIFF
--- a/dev-scripts/enable-git-hooks
+++ b/dev-scripts/enable-git-hooks
@@ -22,4 +22,4 @@ then
   rm -rf .git/hooks
 fi
 
-ln --symbolic --force ../dev-scripts/git-hooks .git/hooks
+ln -s -f ../dev-scripts/git-hooks .git/hooks


### PR DESCRIPTION
The ln command are broken under Apple Mac. The long form args are not available under.