### PR TITLE
URL-encode expiration timestamp

### DIFF
--- a/static/js/controllers/upload.js
+++ b/static/js/controllers/upload.js
@@ -3,7 +3,7 @@
 export async function uploadFile(file, expirationTime) {
   const formData = new FormData();
   formData.append("file", file);
-  return fetch(`/api/entry?expiration=${expirationTime}`, {
+  return fetch(`/api/entry?expiration=${encodeURIComponent(expirationTime)}`, {
     method: "POST",
     credentials: "include",
     body: formData,


### PR DESCRIPTION
Otherwise, + character gets converted to a space when the server parses it, which causes expiration time parsing to fail.

Fixes #139