### PR TITLE
Fix CSS for delete in file table

### DIFF
--- a/static/js/fileIndex.js
+++ b/static/js/fileIndex.js
@@ -17,8 +17,15 @@ document.querySelectorAll('[pico-purpose="delete"]').forEach((deleteBtn) => {
     const id = deleteBtn.getAttribute("pico-entry-id");
     deleteFile(id)
       .then(() => {
-        const rowEl = deleteBtn.parentElement.parentElement;
-        rowEl.classList.add("deleted-entry");
+        let currentEl = deleteBtn.parentElement;
+        while (currentEl && currentEl.nodeName !== "TR") {
+          currentEl = currentEl.parentElement;
+        }
+        if (!currentEl) {
+          return;
+        }
+
+        currentEl.classList.add("deleted-entry");
       })
       .catch((error) => {
         document.getElementById("error-message").innerText = error;


### PR DESCRIPTION
The logic for finding the row was flimsy and we accidentally broke it in c1ce1b30a5d29f340597debd87769f6071484ef5.