### PR TITLE
Fix types.NeverExpire to be 2999-12-31

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -27,4 +27,4 @@ type (
 )
 
 // Treat a distant expiration time as sort of a sentinel value signifying a "never expire" option.
-var NeverExpire = ExpirationTime(time.Date(3000, time.January, 0, 0, 0, 0, 0, time.UTC))
+var NeverExpire = ExpirationTime(time.Date(2999, time.December, 31, 0, 0, 0, 0, time.UTC))


### PR DESCRIPTION
I meant for this to be 3000-01-01, but I accidentally formatted it as 3000-01-00, which ticks back to 2999-12-31, so let's just use that as the NeverExpire time.

Fixes #151