### PR TITLE
Use PBKDF2 to hash shared secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,11 @@ require (
 	github.com/mtlynch/gorilla-handlers v1.5.2
 )
 
-require github.com/felixge/httpsnoop v1.0.1 // indirect
+require (
+	github.com/felixge/httpsnoop v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
+	golang.org/x/net v0.0.0-20220401154927-543a649e0bdd // indirect
+	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,13 @@ github.com/mattn/go-sqlite3 v1.14.11 h1:gt+cp9c0XGqe9S/wAHTL3n/7MqY+siPWgWJgqdsF
 github.com/mattn/go-sqlite3 v1.14.11/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mtlynch/gorilla-handlers v1.5.2 h1:CnOI7baYzjgdumJMc7Dh192JFxqGsNgRewa7NTqq9Pc=
 github.com/mtlynch/gorilla-handlers v1.5.2/go.mod h1:qZmXSCK7pPjN71Pl9ARbQX2ec1t11FI/j8bDS+ZVbmQ=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20220401154927-543a649e0bdd h1:zYlwaUHTmxuf6H7hwO2dgwqozQmH7zf4x+/qql4oVWc=
+golang.org/x/net v0.0.0-20220401154927-543a649e0bdd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/handlers/auth/shared_secret/shared_secret.go
+++ b/handlers/auth/shared_secret/shared_secret.go
@@ -1,25 +1,29 @@
 package shared_secret
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
+
+	"golang.org/x/crypto/pbkdf2"
 )
 
 const authCookieName = "sharedSecret"
 
 type (
-	sharedSecret string
+	sharedSecret []byte
 
 	SharedSecretAuthenticator struct {
 		sharedSecret sharedSecret
 	}
 )
 
-func New(sharedSecret string) (SharedSecretAuthenticator, error) {
-	ss, err := parseSharedSecret(sharedSecret)
+func New(sharedSecretKey string) (SharedSecretAuthenticator, error) {
+	ss, err := sharedSecretFromKey([]byte(sharedSecretKey))
 	if err != nil {
 		return SharedSecretAuthenticator{}, err
 	}
@@ -36,7 +40,7 @@ func (ssa SharedSecretAuthenticator) StartSession(w http.ResponseWriter, r *http
 		return
 	}
 
-	if subtle.ConstantTimeCompare([]byte(ss), []byte(ssa.sharedSecret)) == 0 {
+	if !sharedSecretsEqual(ss, ssa.sharedSecret) {
 		http.Error(w, "Incorrect shared secret", http.StatusUnauthorized)
 		return
 	}
@@ -45,16 +49,16 @@ func (ssa SharedSecretAuthenticator) StartSession(w http.ResponseWriter, r *http
 }
 
 func sharedSecretFromRequest(r *http.Request) (sharedSecret, error) {
-	ar := struct {
-		SharedSecret string `json:"sharedSecret"`
+	body := struct {
+		SharedSecretKey string `json:"sharedSecretKey"`
 	}{}
 	decoder := json.NewDecoder(r.Body)
-	err := decoder.Decode(&ar)
+	err := decoder.Decode(&body)
 	if err != nil {
-		return "", err
+		return sharedSecret{}, err
 	}
 
-	return parseSharedSecret(ar.SharedSecret)
+	return sharedSecretFromKey([]byte(body.SharedSecretKey))
 }
 
 func (ssa SharedSecretAuthenticator) Authenticate(r *http.Request) bool {
@@ -63,22 +67,18 @@ func (ssa SharedSecretAuthenticator) Authenticate(r *http.Request) bool {
 		return false
 	}
 
-	ss, err := parseSharedSecret(authCookie.Value)
+	ss, err := sharedSecretFromBase64(authCookie.Value)
 	if err != nil {
 		return false
 	}
 
-	if ss != ssa.sharedSecret {
-		return false
-	}
-
-	return true
+	return sharedSecretsEqual(ss, ssa.sharedSecret)
 }
 
 func (ssa SharedSecretAuthenticator) createCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     authCookieName,
-		Value:    string(ssa.sharedSecret),
+		Value:    base64.StdEncoding.EncodeToString(ssa.sharedSecret),
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
@@ -97,9 +97,35 @@ func (ssa SharedSecretAuthenticator) ClearSession(w http.ResponseWriter) {
 	})
 }
 
-func parseSharedSecret(s string) (sharedSecret, error) {
-	if len(s) == 0 {
-		return sharedSecret(""), errors.New("invalid shared secret")
+func sharedSecretFromKey(key []byte) (sharedSecret, error) {
+	if len(key) == 0 {
+		return sharedSecret{}, errors.New("invalid shared secret")
 	}
-	return sharedSecret(s), nil
+
+	// These would be insecure values for storing a database of user credentials,
+	// but we're only storing a single password, so it's not important to have
+	// random salt or high iteration rounds.
+	staticSalt := []byte{1, 2, 3, 4}
+	iter := 100
+
+	dk := pbkdf2.Key(key, staticSalt, iter, 32, sha256.New)
+
+	return sharedSecret(dk), nil
+}
+
+func sharedSecretFromBase64(b64encoded string) (sharedSecret, error) {
+	if len(b64encoded) == 0 {
+		return sharedSecret{}, errors.New("invalid shared secret")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(b64encoded)
+	if err != nil {
+		return sharedSecret{}, err
+	}
+
+	return sharedSecret(decoded), nil
+}
+
+func sharedSecretsEqual(a, b sharedSecret) bool {
+	return subtle.ConstantTimeCompare(a, b) != 0
 }

--- a/handlers/auth/shared_secret/shared_secret.go
+++ b/handlers/auth/shared_secret/shared_secret.go
@@ -99,7 +99,7 @@ func (ssa SharedSecretAuthenticator) ClearSession(w http.ResponseWriter) {
 
 func sharedSecretFromKey(key []byte) (sharedSecret, error) {
 	if len(key) == 0 {
-		return sharedSecret{}, errors.New("invalid shared secret")
+		return sharedSecret{}, errors.New("invalid shared secret key")
 	}
 
 	// These would be insecure values for storing a database of user credentials,

--- a/static/js/controllers/auth.js
+++ b/static/js/controllers/auth.js
@@ -6,7 +6,7 @@ export async function authenticate(passphrase) {
     cache: "no-cache",
     redirect: "error",
     body: JSON.stringify({
-      sharedSecret: passphrase,
+      sharedSecretKey: passphrase,
     }),
   }).then((response) => {
     if (!response.ok) {


### PR DESCRIPTION
We were previously storing the password in plaintext as a cookie. This was insecure, but fairly low risk because in order to compromise the key, an attacker would need to compromise the user's browser (beyond XSS, as it's an HttpOnly key).

Storing the secret in plaintext additionally had the problem of not properly encoding characters that are not allowed in HTTP cookies.

This change hashes passwords with PBKDF2 and stores the result as base64-encoded bytes.

Fixes #166