### PR TITLE
Scratch: Simple approach to SQLite migrations

### DIFF
--- a/store/sqlite/migrations/001-create-entries-table.sql
+++ b/store/sqlite/migrations/001-create-entries-table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS entries (
+  id TEXT PRIMARY KEY,
+  filename TEXT,
+  content_type TEXT,
+  upload_time TEXT,
+  expiration_time TEXT
+);

--- a/store/sqlite/migrations/002-create-entries_data-table.sql
+++ b/store/sqlite/migrations/002-create-entries_data-table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS entries_data (
+  id TEXT,
+  chunk_index INTEGER,
+  chunk BLOB,
+  FOREIGN KEY(id) REFERENCES entries(id)
+);

--- a/store/sqlite/migrations/003-create-guest_links-and-modify-entries.sql
+++ b/store/sqlite/migrations/003-create-guest_links-and-modify-entries.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS guest_links (
+  id TEXT PRIMARY KEY,
+  label TEXT,
+  uploads_left INTEGER,
+  upload_bytes_left INTEGER,
+  expiration_time TEXT
+  );
+
+ALTER TABLE entries RENAME TO old_entries;
+
+CREATE TABLE IF NOT EXISTS entries (
+  id TEXT PRIMARY KEY,
+  filename TEXT,
+  content_type TEXT,
+  upload_time TEXT,
+  expiration_time TEXT,
+  guest_link_id TEXT,
+  FOREIGN KEY(guest_link_id) REFERENCES guest_links(id)
+);
+
+INSERT INTO entries SELECT *, '' FROM old_entries;
+
+DROP TABLE old_entries;

--- a/store/sqlite/migrations/004-add-label-column-to-entries-table.sql
+++ b/store/sqlite/migrations/004-add-label-column-to-entries-table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries ADD COLUMN label TEXT;

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -59,7 +59,7 @@ func NewWithChunkSize(path string, chunkSize int) store.Store {
 	// 3 and 4 mutate the table to add functionality for users who have already
 	// provisioned their database in <= 1.0.6.
 	migrations := []dbMigration{
-		// 0: Create entries table.
+		// 1: Create entries table.
 		{
 			`CREATE TABLE IF NOT EXISTS entries (
 			id TEXT PRIMARY KEY,
@@ -69,7 +69,7 @@ func NewWithChunkSize(path string, chunkSize int) store.Store {
 			expiration_time TEXT
 			)`,
 		},
-		// 1: Create entries_data table.
+		// 2: Create entries_data table.
 		{
 			`CREATE TABLE IF NOT EXISTS entries_data (
 			id TEXT,

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -100,7 +100,7 @@ func NewWithChunkSize(path string, chunkSize int) store.Store {
 			`INSERT INTO entries SELECT *, '' FROM old_entries`,
 			`DROP TABLE old_entries`,
 		},
-		// 4: Create guest_links table and reference it from entries table.
+		// 4: Add label column to entries table.
 		{
 			`ALTER TABLE entries ADD COLUMN label TEXT`,
 		},


### PR DESCRIPTION
This applies SQLite migrations without using any external tool.

Users who installed PicoShare 1.0.6 or below will already have their database set up, so we need an easy way for them to upgrade forward to new database schemas. This implementation achieves that by saving a schema version number in PRAGMA user_version. If the user's user_version is below the total number of migrations available, we apply migrations starting at migrations[user_version].

This is a proof-of-concept for now.