### PR TITLE
Disallow empty file uploads and refactor unit tests

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -171,6 +171,10 @@ func fileFromRequest(w http.ResponseWriter, r *http.Request) (fileUpload, error)
 		return fileUpload{}, err
 	}
 
+	if metadata.Size == 0 {
+		return fileUpload{}, errors.New("file is empty")
+	}
+
 	filename, err := parse.Filename(metadata.Filename)
 	if err != nil {
 		return fileUpload{}, err

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -141,7 +141,6 @@ func TestGuestUploadValidFile(t *testing.T) {
 
 	filename := "dummyimage.png"
 	contents := "dummy bytes"
-	// Guest uploads can't have notes
 	formData, contentType := createMultipartFormBody(filename, makeData(contents))
 
 	req, err := http.NewRequest("POST", "/api/guest/abcdefgh23456789", formData)


### PR DESCRIPTION
Our unit tests weren't testing the upload method correctly, so even though we thought we were testing for empty uploads, we weren't really rejecting those requests.

This refactors the tests to fix the test bug and changes the upload POST behavior to reject uploads of empty files.