### PR TITLE
Make file size type int64 instead of int

### DIFF
--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -66,12 +66,12 @@ func TestCollectExpiredFile(t *testing.T) {
 		{
 			ID:      types.EntryID("BBBBBBBBBBBB"),
 			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    len(d),
+			Size:    int64(len(d)),
 		},
 		{
 			ID:      types.EntryID("CCCCCCCCCCCC"),
 			Expires: types.NeverExpire,
-			Size:    len(d),
+			Size:    int64(len(d)),
 		},
 	}
 	if !reflect.DeepEqual(expected, remaining) {
@@ -118,17 +118,17 @@ func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
 		{
 			ID:      types.EntryID("AAAAAAAAAAAA"),
 			Expires: mustParseExpirationTime("4000-01-01T00:00:00Z"),
-			Size:    len(d),
+			Size:    int64(len(d)),
 		},
 		{
 			ID:      types.EntryID("BBBBBBBBBBBB"),
 			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    len(d),
+			Size:    int64(len(d)),
 		},
 		{
 			ID:      types.EntryID("CCCCCCCCCCCC"),
 			Expires: types.NeverExpire,
-			Size:    len(d),
+			Size:    int64(len(d)),
 		},
 	}
 	if !reflect.DeepEqual(expected, remaining) {

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -177,7 +177,7 @@ func (s Server) fileIndexGet() http.HandlerFunc {
 				delta := time.Until(t)
 				return fmt.Sprintf("%s (%.0f days)", t.Format("2006-01-02"), delta.Hours()/24)
 			},
-			"formatFileSize": func(b int) string {
+			"formatFileSize": func(b int64) string {
 				const unit = 1024
 
 				if b < unit {

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -139,7 +139,7 @@ func (d db) GetEntriesMetadata() ([]types.UploadMetadata, error) {
 		var contentType string
 		var uploadTimeRaw string
 		var expirationTimeRaw string
-		var fileSize int
+		var fileSize int64
 		err = rows.Scan(&id, &filename, &note, &contentType, &uploadTimeRaw, &expirationTimeRaw, &fileSize)
 		if err != nil {
 			return []types.UploadMetadata{}, err

--- a/store/sqlite/sqlite_test.go
+++ b/store/sqlite/sqlite_test.go
@@ -48,7 +48,7 @@ func TestInsertDeleteSingleEntry(t *testing.T) {
 		t.Fatalf("unexpected metadata size: got %v, want %v", len(meta), 1)
 	}
 
-	if meta[0].Size != len(expected) {
+	if meta[0].Size != int64(len(expected)) {
 		t.Fatalf("unexpected file size in entry metadata: got %v, want %v", meta[0].Size, len(expected))
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -20,7 +20,7 @@ type (
 		ContentType ContentType
 		Uploaded    time.Time
 		Expires     ExpirationTime
-		Size        int
+		Size        int64
 	}
 
 	UploadEntry struct {


### PR DESCRIPTION
File sizes can be larger than 32-bits, so we should explicitly use a 64-bit int to store it.