### PR TITLE
Create an index for calculating file sizes quickly

### DIFF
--- a/store/sqlite/migrations/.sqlfluffignore
+++ b/store/sqlite/migrations/.sqlfluffignore
@@ -1,0 +1,3 @@
+# sqlfluff fails to parse this file even though it's valid SQLite
+# https://github.com/sqlfluff/sqlfluff/issues/3237
+005-add-chunk-length-index.sql

--- a/store/sqlite/migrations/005-add-chunk-length-index.sql
+++ b/store/sqlite/migrations/005-add-chunk-length-index.sql
@@ -1,0 +1,3 @@
+-- Create an index for fast file size calculation.
+-- https://github.com/mtlynch/picoshare/issues/220
+CREATE INDEX length_index ON entries_data(id, LENGTH(chunk));

--- a/store/sqlite/migrations/005-add-chunk-length-index.sql
+++ b/store/sqlite/migrations/005-add-chunk-length-index.sql
@@ -1,4 +1,4 @@
 -- Create an index for fast file size calculation.
 -- https://github.com/mtlynch/picoshare/issues/220
-CREATE INDEX li1
+CREATE INDEX idx_entries_data_length
 ON entries_data(id, LENGTH(chunk));

--- a/store/sqlite/migrations/005-add-chunk-length-index.sql
+++ b/store/sqlite/migrations/005-add-chunk-length-index.sql
@@ -1,3 +1,4 @@
 -- Create an index for fast file size calculation.
 -- https://github.com/mtlynch/picoshare/issues/220
-CREATE INDEX length_index ON entries_data(id, LENGTH(chunk));
+CREATE INDEX li1
+ON entries_data(id, LENGTH(chunk));


### PR DESCRIPTION
Without an index, calling `LENGTH` on blob data reads all of the data into memory. When the database gets to > 1 GB in data, this can take 10+ seconds for simple queries, which is too slow.

Adding the index drops the latency down to a few milliseconds, so it's a fairly simple solution.

I originally thought we'd have to store a redundant copy of the file size (see #221), but the index implementation is much simpler and less bug-prone.

Fixes #220 