### PR TITLE
Use stock Prettier to format custom elements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "overrides": [
     {
-      "files": ["*.html"],
+      "files": ["templates/*.html"],
       "options": {
         "parser": "go-template"
       }

--- a/templates/custom-elements/snackbar-notifications.html
+++ b/templates/custom-elements/snackbar-notifications.html
@@ -1,5 +1,5 @@
-<template id="snackbar-notifications-template"
-  >  <style nonce="{{ .CspNonce }}">
+<template id="snackbar-notifications-template">
+  <style nonce="{{ .CspNonce }}">
     #notifications {
       position: fixed;
       bottom: 0px;
@@ -40,8 +40,10 @@
       }
     }
   </style>
-  <div id="notifications"></div> </template
-><script type="module" nonce="{{ .CspNonce }}">
+  <div id="notifications"></div>
+</template>
+
+<script type="module" nonce="{{ .CspNonce }}">
   (function () {
     const template = document.querySelector("#snackbar-notifications-template");
 

--- a/templates/custom-elements/upload-link-box.html
+++ b/templates/custom-elements/upload-link-box.html
@@ -1,5 +1,5 @@
-<template id="upload-link-box-template"
-  >  <style nonce="{{ .CspNonce }}">
+<template id="upload-link-box-template">
+  <style nonce="{{ .CspNonce }}">
     @import "/third-party/bulma@0.9.3/bulma.min.css";
     @import "/third-party/fontawesome6/css/all.min.css";
 
@@ -11,7 +11,8 @@
       height: 1.5em;
     }
 
-    .box button, .box button span {
+    .box button,
+    .box button span {
       font-size: 7pt;
     }
   </style>
@@ -27,8 +28,9 @@
     <p class="light-font mt-3">
       <slot></slot>
     </p>
-  </div> </template
->
+  </div>
+</template>
+
 <script type="module" nonce="{{ .CspNonce }}">
   import { copyToClipboard } from "/js/lib/clipboard.js";
 
@@ -43,13 +45,13 @@
             template.content.cloneNode(true)
           );
           this.href = this.getAttribute("href");
-          this.shadowRoot.getElementById("copy-btn").addEventListener("click",
-            () => {
+          this.shadowRoot
+            .getElementById("copy-btn")
+            .addEventListener("click", () => {
               copyToClipboard(this.href).then(() => {
                 this.emitLinkCopied();
               });
-            }
-          )
+            });
         }
 
         attributeChangedCallback(name, oldValue, newValue) {

--- a/templates/custom-elements/upload-links.html
+++ b/templates/custom-elements/upload-links.html
@@ -1,5 +1,5 @@
-<template id="upload-links-template"
-  >  <style nonce="{{ .CspNonce }}">
+<template id="upload-links-template">
+  <style nonce="{{ .CspNonce }}">
     .box-wrapper + .box-wrapper {
       margin-top: 1rem;
     }
@@ -13,8 +13,9 @@
     <upload-link-box id="short-link-box">
       <slot>Shortlink</slot>
     </upload-link-box>
-  </div> </template
->
+  </div>
+</template>
+
 <script type="module" nonce="{{ .CspNonce }}">
   import { makeShortLink, makeVerboseLink } from "/js/lib/links.js";
 
@@ -57,8 +58,9 @@
 
           this.shadowRoot.getElementById("verbose-link-box").href =
             makeVerboseLink(this.fileId, this.filename);
-          this.shadowRoot.getElementById("short-link-box").href =
-            makeShortLink(this.fileId);
+          this.shadowRoot.getElementById("short-link-box").href = makeShortLink(
+            this.fileId
+          );
         }
       }
     );


### PR DESCRIPTION
There seems to be a bug in prettier-plugin-go-template that prevents it from formatting custom elements correctly when they contain Go template syntax, so we're tightening the matcher for Go templates to not match HTML custom elements.

See: https://github.com/NiklasPor/prettier-plugin-go-template/issues/84