### PR TITLE
Remove workaround for prettier-plugin-go-template bug

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "overrides": [
     {
-      "files": ["templates/*.html"],
+      "files": ["*.html"],
       "options": {
         "parser": "go-template"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -578,9 +578,9 @@
       "dev": true
     },
     "prettier-plugin-go-template": {
-      "version": "0.0.13-beta.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.13-beta.1.tgz",
-      "integrity": "sha512-KT42C0GjVoAlETzD8dGwoEWbdmLGaWllYU0IjDb8dzfuimoOI3W1yDmhKYTIcvYa0ntxSYSWhlnosaa0u5vd7g==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.13.tgz",
+      "integrity": "sha512-gG/xT5kd+kCzoMaTchXvdfBdsunyRCV6G8cgdPGPd2V5JGGKXUG7SjzBKU7jaGh2RTeblcAdBb/E+S/duOAMsA==",
       "dev": true,
       "requires": {
         "ulid": "^2.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -578,9 +578,9 @@
       "dev": true
     },
     "prettier-plugin-go-template": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.12.tgz",
-      "integrity": "sha512-3LGFSjUTwirXa56dY7ZbNETM5nMUc5TKPYyo7cJx/8mdMnWUCMKTVzBQ3K7xUk2+D4g8CLADQ3Nc1HZ5SNWeag==",
+      "version": "0.0.13-beta.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.13-beta.1.tgz",
+      "integrity": "sha512-KT42C0GjVoAlETzD8dGwoEWbdmLGaWllYU0IjDb8dzfuimoOI3W1yDmhKYTIcvYa0ntxSYSWhlnosaa0u5vd7g==",
       "dev": true,
       "requires": {
         "ulid": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "eslint": "^8.11.0",
     "eslint-plugin-cypress": "^2.12.1",
     "prettier": "^2.6.0",
-    "prettier-plugin-go-template": "0.0.13-beta.1"
+    "prettier-plugin-go-template": "0.0.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "eslint": "^8.11.0",
     "eslint-plugin-cypress": "^2.12.1",
     "prettier": "^2.6.0",
-    "prettier-plugin-go-template": "0.0.12"
+    "prettier-plugin-go-template": "0.0.13-beta.1"
   }
 }


### PR DESCRIPTION
Related: #254

This is gated on the official release of [prettier-plugin-go-template](https://github.com/NiklasPor/prettier-plugin-go-template) 0.13.0