### PR TITLE
Debugging OOM error

### DIFF
--- a/cmd/picoshare/main_test.go
+++ b/cmd/picoshare/main_test.go
@@ -1,0 +1,70 @@
+package main_test
+
+import (
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gorilla "github.com/mtlynch/gorilla-handlers"
+	"github.com/mtlynch/picoshare/v2/handlers"
+	"github.com/mtlynch/picoshare/v2/store/sqlite"
+)
+
+func TestUpload(t *testing.T) {
+	const fileSize = 5 * (1 << 30) // 5GB
+
+	// Start HTTP server and wait a moment for it to kick in.
+	store := sqlite.New(filepath.Join(t.TempDir(), "db"))
+	http.Handle("/", gorilla.LoggingHandler(os.Stdout, handlers.New(nil, store).Router()))
+	go http.ListenAndServe(":9000", nil)
+	time.Sleep(1 * time.Second)
+
+	// Write the multi-part form through a pipe so we don't need to allocate it ahead of time.
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		fw, err := mw.CreateFormFile("file", "foo.dat")
+		if err != nil {
+			t.Fatal(err)
+		} else if _, err := io.CopyN(fw, &zeroReader{}, fileSize); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := mw.Close(); err != nil {
+			t.Fatal(err)
+		} else if err := pw.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Send request and hope for the best.
+	req, err := http.NewRequest("POST", "http://localhost:9000/api/entry?expiration=2030-01-01T00:00:00Z", pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got, want := resp.StatusCode, 200; got != want {
+		t.Fatalf("StatusCode=%v, want %v", got, want)
+	}
+}
+
+// zeroReader implements io.Reader and always fills the buffer with zeros.
+type zeroReader struct{}
+
+func (r *zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -5,10 +5,10 @@ import "net/http"
 func (s *Server) routes() {
 	s.router.HandleFunc("/api/auth", s.authPost()).Methods(http.MethodPost)
 	s.router.HandleFunc("/api/auth", s.authDelete()).Methods(http.MethodDelete)
-	s.router.Use(s.checkAuthentication)
+	// s.router.Use(s.checkAuthentication)
 
 	authenticatedApis := s.router.PathPrefix("/api").Subrouter()
-	authenticatedApis.Use(s.requireAuthentication)
+	// authenticatedApis.Use(s.requireAuthentication)
 	authenticatedApis.HandleFunc("/entry", s.entryPost()).Methods(http.MethodPost)
 	authenticatedApis.HandleFunc("/entry/{id}", s.entryPut()).Methods(http.MethodPut)
 	authenticatedApis.HandleFunc("/entry/{id}", s.entryDelete()).Methods(http.MethodDelete)
@@ -40,7 +40,7 @@ func (s *Server) routes() {
 	}
 
 	authenticatedViews := s.router.PathPrefix("/").Subrouter()
-	authenticatedViews.Use(s.requireAuthentication)
+	// authenticatedViews.Use(s.requireAuthentication)
 	authenticatedViews.Use(enforceContentSecurityPolicy)
 	authenticatedViews.HandleFunc("/files", s.fileIndexGet()).Methods(http.MethodGet)
 	authenticatedViews.HandleFunc("/files/{id}/edit", s.fileEditGet()).Methods(http.MethodGet)

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -243,7 +243,7 @@ func fileFromRequest(w http.ResponseWriter, r *http.Request) (fileUpload, error)
 	// We're intentionally not limiting the size of the request because we assume
 	// the the uploading user is trusted, so they can upload files of any size
 	// they want.
-	r.ParseMultipartForm(32 << 20)
+	r.ParseMultipartForm(1 << 20)
 	reader, metadata, err := r.FormFile("file")
 	if err != nil {
 		return fileUpload{}, err


### PR DESCRIPTION
I believe I figured out your OOM issue when uploading large files in picoshare as mentioned in [your Twitter thread](https://twitter.com/deliberatecoder/status/1552438652537835521). It ended up being a very minor change (isn't it always!?) but I'll try to describe my method of tracking it down.

## Setting up a test

First, I wrote up an end-to-end test case to upload a large file. This is almost always my first step when profiling (if possible) as it lets me quickly iterate. I ended up axing the authentication and commented out auth in the routes so I'll let you fix that up if you want to. :)

## Running the initial profile

Next, I ran the `go test` and set the `-memprofile` flag so I could get all the allocations for a single upload:

```sh
go test -v -memprofile /tmp/mem.pprof -run=TestUpload ./cmd/picoshare
```

Then open that in the pprof tool:

```sh
go tool pprof /tmp/mem.pprof
```

My "go to" command in pprof if the `web` command. It generates an SVG via graphviz and pops it up in your web browser.

When it's generated from a `go test` run, it defaults to show the `alloc_space` mode which means it shows the number of bytes allocated across the entire execution. There's another mode called `inuse_space` which only shows bytes that are currently allocated and you typically use that when you're live profiling from a pprof HTTP endpoint.

Two other modes are `alloc_object` and `inuse_object` which show the number of individual objects allocated instead of number of bytes. These modes are useful if you're trying to reduce GC overhead instead of reducing the actual number of bytes in memory. That's not our concern here though.

In addition to the `web` command, there's a `pdf` command which also show a graphviz graph but it's exported to a file format that's easier to share in, say, a GitHub PR. 
[profile001.pdf](https://github.com/mtlynch/picoshare/files/9212002/profile001.pdf)

We can see that there's a lot of large allocations from `bytes.makeSlice()`. The part to make note of is the gray cubes at the bottom that say "64MB", "32MB", etc. The number in the box is the size of the individual allocation. The number next to the arrow line above it is the total size of all the allocations of that size. So for the 64MB allocation, we can see 64MB above it so that means that only 1 allocation was made of that size. For the "512kB..8MB" box (which groups allocations in a range of sizes), we can see 15.99MB which means the total size of allocations of objects in that size range is 15.99MB.

<img width="395" alt="Screen Shot 2022-07-28 at 9 16 53 AM" src="https://user-images.githubusercontent.com/118015/181574596-5c31e1e3-be44-4a27-9754-194bbea0b9fb.png">

If we walk up the stack we can see it stems from this call from your application to `ParseMultipartForm()`:

<img width="187" alt="Screen Shot 2022-07-28 at 9 21 18 AM" src="https://user-images.githubusercontent.com/118015/181575544-32daecbc-67c6-442f-9c86-39d3b6fca056.png">

Looking at the docs for [http.Request.ParseMultipartForm()](https://pkg.go.dev/net/http#Request.ParseMultipartForm) we can see the following:

> _The whole request body is parsed and up to a total of maxMemory bytes of its file parts are stored in memory, with the remainder stored on disk in temporary files._

Picoshare uses the default size of 32 << 20 (or 32MB) so it seems like the fact that Go allocated a 64MB chunk is a bug. Anyway, we can change that value to something more reasonable like 1 << 20 (1MB).


## Verifying the change

Just to make sure that this actually worked, we can rerun the test:

```sh
go test -v -memprofile /tmp/mem.pprof -run=TestUpload ./cmd/picoshare
```

Then open pprof and generate out the graph: 
[profile002.pdf](https://github.com/mtlynch/picoshare/files/9212068/profile002.pdf)

And voila! It looks like the maximum size allocated by `ParseMultipartForm()` is only 2MB instead of 64MB:

<img width="599" alt="Screen Shot 2022-07-28 at 9 25 31 AM" src="https://user-images.githubusercontent.com/118015/181576499-efbee040-b0fa-46b2-8c8b-937c5dc704e1.png">

## More fun with pprof 

### `call_tree`

One thing that can get in the way of debugging memory is that pprof will join back calls to the same function—even if the stacks are different. So for example, multiple calls to `io.Copy()` all get joined together so you can't actually see which stack allocated which memory.

<img width="643" alt="Screen Shot 2022-07-28 at 9 29 37 AM" src="https://user-images.githubusercontent.com/118015/181577444-779b54d3-729b-4531-8eac-0af2dae5c69d.png">

You can use the `call_tree` command in `pprof` to split all the call stacks out so they don't join anymore. Now we can clearly see only the allocations for our form parsing:
 
<img width="307" alt="Screen Shot 2022-07-28 at 9 30 59 AM" src="https://user-images.githubusercontent.com/118015/181577775-ca0d2502-3481-4477-8e5b-16923e1f96ae.png">

### `weblist`

Another useful command is `weblist`. It'll show functions matching a regex and print out their code along with exactly what lines allocated how much.

```
pprof> weblist flush
```

produces this:

<img width="717" alt="Screen Shot 2022-07-28 at 9 33 42 AM" src="https://user-images.githubusercontent.com/118015/181578380-f6fe09ef-c7f9-4a22-bd78-b724fc91079b.png">

