### PR TITLE
Fix a SQL mistake in file reader

### DIFF
--- a/store/sqlite/file/reader.go
+++ b/store/sqlite/file/reader.go
@@ -95,7 +95,7 @@ func (fr *fileReader) populateBuffer() error {
 				entries_data
 			WHERE
 				id=? AND
-				chunk_index>=?
+				chunk_index=?
 			ORDER BY
 				chunk_index ASC
 			`)


### PR DESCRIPTION
In #284, @danwilhelm spotted a mistake in the reader.go implementation where the populateBuffer reads not only the current chunk but all subsequent chunks in the file and then discards them. There was no reason for reading the remaining chunks as far as I remember, so I think this was just a simple oversight.

This change changes the SQL comparison from >= to =.