### PR TITLE
Use less RAM while parsing a multipart form

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -246,7 +246,7 @@ func fileFromRequest(w http.ResponseWriter, r *http.Request) (fileUpload, error)
 
 	// ParseMultipartForm can go above the limit we set, so set a conservative RAM
 	// limit to avoid exhausting RAM on servers with limited resources.
-	multipartMaxMemory := bytesToMB(5)
+	multipartMaxMemory := bytesToMiB(1)
 	r.ParseMultipartForm(multipartMaxMemory)
 	reader, metadata, err := r.FormFile("file")
 	if err != nil {
@@ -297,6 +297,6 @@ func parseExpirationFromRequest(r *http.Request) (types.ExpirationTime, error) {
 	return parse.Expiration(expirationRaw[0])
 }
 
-func bytesToMB(b int64) int64 {
+func bytesToMiB(b int64) int64 {
 	return b * 1024 * 1024
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -246,7 +246,7 @@ func fileFromRequest(w http.ResponseWriter, r *http.Request) (fileUpload, error)
 
 	// ParseMultipartForm can go above the limit we set, so set a conservative RAM
 	// limit to avoid exhausting RAM on servers with limited resources.
-	multipartMaxMemory := bytesToMiB(1)
+	multipartMaxMemory := mibToBytes(1)
 	r.ParseMultipartForm(multipartMaxMemory)
 	reader, metadata, err := r.FormFile("file")
 	if err != nil {
@@ -297,6 +297,7 @@ func parseExpirationFromRequest(r *http.Request) (types.ExpirationTime, error) {
 	return parse.Expiration(expirationRaw[0])
 }
 
-func bytesToMiB(b int64) int64 {
-	return b << 20
+// mibToBytes converts an amount in MiB to an amount in bytes.
+func mibToBytes(i int64) int64 {
+	return i << 20
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -298,5 +298,5 @@ func parseExpirationFromRequest(r *http.Request) (types.ExpirationTime, error) {
 }
 
 func bytesToMiB(b int64) int64 {
-	return b * 1024 * 1024
+	return b << 20
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -243,7 +243,11 @@ func fileFromRequest(w http.ResponseWriter, r *http.Request) (fileUpload, error)
 	// We're intentionally not limiting the size of the request because we assume
 	// the the uploading user is trusted, so they can upload files of any size
 	// they want.
-	r.ParseMultipartForm(32 << 20)
+
+	// ParseMultipartForm can go above the limit we set, so set a conservative RAM
+	// limit to avoid exhausting RAM on servers with limited resources.
+	multipartMaxMemory := bytesToMB(5)
+	r.ParseMultipartForm(multipartMaxMemory)
 	reader, metadata, err := r.FormFile("file")
 	if err != nil {
 		return fileUpload{}, err
@@ -291,4 +295,8 @@ func parseExpirationFromRequest(r *http.Request) (types.ExpirationTime, error) {
 		return types.ExpirationTime{}, errors.New("missing required URL parameter: expiration")
 	}
 	return parse.Expiration(expirationRaw[0])
+}
+
+func bytesToMB(b int64) int64 {
+	return b * 1024 * 1024
 }


### PR DESCRIPTION
As @benbjohnson (#283) and @danwilhelm (#284) have found, using 32 << 20 (32 MiB) as the limit in ParseMultipartForm actually consumes significantly more than 32 MiB of RAM.

This changes the limit to 1 MiB so that we avoid consuming too much RAM on the system.