### PR TITLE
Switch back to single brackets in shell conditionals in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ COPY ./go.* /app/
 WORKDIR /app
 
 RUN set -x && \
-    if [[ "$TARGETPLATFORM" = "linux/arm/v7" ]]; then \
+    if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
       GOARCH="arm"; \
-    elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       GOARCH="arm64"; \
     else \
       GOARCH="amd64"; \
@@ -44,9 +44,9 @@ RUN set -x && \
       wget
 
 RUN set -x && \
-    if [[ "$TARGETPLATFORM" = "linux/arm/v7" ]]; then \
+    if [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
       ARCH="arm7" ; \
-    elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       ARCH="arm64" ; \
     else \
       ARCH="amd64" ; \


### PR DESCRIPTION
In some contexts, we're evaluating with /bin/sh instead of /bin/bash, so we can't use the bash syntax

Related: eb82af099d328f1bcb47e6bce4105adcf3b9d72b