### PR TITLE
Rename startChunk to chunkIndex

### DIFF
--- a/store/sqlite/file/reader.go
+++ b/store/sqlite/file/reader.go
@@ -87,7 +87,7 @@ func (fr *fileReader) populateBuffer() error {
 		return io.EOF
 	}
 
-	startChunk := fr.offset / int64(fr.chunkSize)
+	chunkIndex := fr.offset / int64(fr.chunkSize)
 	var chunk []byte
 	if err := fr.db.QueryRow(`
 			SELECT
@@ -99,7 +99,7 @@ func (fr *fileReader) populateBuffer() error {
 				chunk_index=?
 			ORDER BY
 				chunk_index ASC
-			`, fr.entryID, startChunk).Scan(&chunk); err != nil {
+			`, fr.entryID, chunkIndex).Scan(&chunk); err != nil {
 		log.Printf("reading chunk failed: %v", err)
 		return err
 	}


### PR DESCRIPTION
We're only reading one chunk at a time, so chunkIndex is a more accurate name.