### PR TITLE
Delete expired entries in Purge

### DIFF
--- a/garbagecollect/collect.go
+++ b/garbagecollect/collect.go
@@ -1,9 +1,7 @@
 package garbagecollect
 
 import (
-	"log"
 	"sync"
-	"time"
 
 	"github.com/mtlynch/picoshare/v2/store"
 )
@@ -25,12 +23,6 @@ func (c *Collector) Collect() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// TODO: Push this into Purge, as we could probably do it more efficiently
-	// in SQL.
-	if err := c.deleteExpiredEntries(); err != nil {
-		return err
-	}
-
 	if err := c.store.Purge(); err != nil {
 		return err
 	}
@@ -40,26 +32,6 @@ func (c *Collector) Collect() error {
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (c *Collector) deleteExpiredEntries() error {
-	log.Printf("deleting expired entries")
-	mm, err := c.store.GetEntriesMetadata()
-	if err != nil {
-		return err
-	}
-
-	for _, meta := range mm {
-		if time.Now().After(time.Time(meta.Expires)) {
-			log.Printf("entry %v expired at %v", meta.ID, time.Time(meta.Expires).Format(time.RFC3339))
-			if err := c.store.DeleteEntry(meta.ID); err != nil {
-				return err
-			}
-		}
-	}
-	log.Printf("finished deleting expired entries")
 
 	return nil
 }

--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -34,6 +34,7 @@ func TestCollectDoesNothingWhenStoreIsEmpty(t *testing.T) {
 func TestCollectExpiredFile(t *testing.T) {
 	dataStore := test_sqlite.New()
 	d := "dummy data"
+	expireInFiveMins := makeRelativeExpirationTime(5 * time.Minute)
 	dataStore.InsertEntry(strings.NewReader(d),
 		types.UploadMetadata{
 			ID:      types.EntryID("AAAAAAAAAAAA"),
@@ -52,7 +53,12 @@ func TestCollectExpiredFile(t *testing.T) {
 	dataStore.InsertEntry(strings.NewReader(d),
 		types.UploadMetadata{
 			ID:      types.EntryID("DDDDDDDDDDDD"),
-			Expires: types.ExpirationTime(time.Now().Add(-time.Second)),
+			Expires: makeRelativeExpirationTime(-1 * time.Second),
+		})
+	dataStore.InsertEntry(strings.NewReader(d),
+		types.UploadMetadata{
+			ID:      types.EntryID("EEEEEEEEEEEE"),
+			Expires: expireInFiveMins,
 		})
 
 	c := garbagecollect.NewCollector(dataStore, false)
@@ -75,6 +81,11 @@ func TestCollectExpiredFile(t *testing.T) {
 		{
 			ID:      types.EntryID("CCCCCCCCCCCC"),
 			Expires: types.NeverExpire,
+			Size:    int64(len(d)),
+		},
+		{
+			ID:      types.EntryID("EEEEEEEEEEEE"),
+			Expires: expireInFiveMins,
 			Size:    int64(len(d)),
 		},
 	}
@@ -146,4 +157,8 @@ func mustParseExpirationTime(s string) types.ExpirationTime {
 		panic(err)
 	}
 	return types.ExpirationTime(et)
+}
+
+func makeRelativeExpirationTime(delta time.Duration) types.ExpirationTime {
+	return types.ExpirationTime(time.Now().UTC().Add(delta).Truncate(time.Second))
 }

--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -49,6 +49,11 @@ func TestCollectExpiredFile(t *testing.T) {
 			ID:      types.EntryID("CCCCCCCCCCCC"),
 			Expires: types.NeverExpire,
 		})
+	dataStore.InsertEntry(strings.NewReader(d),
+		types.UploadMetadata{
+			ID:      types.EntryID("DDDDDDDDDDDD"),
+			Expires: types.ExpirationTime(time.Now().Add(-time.Second)),
+		})
 
 	c := garbagecollect.NewCollector(dataStore, false)
 	err := c.Collect()

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -466,8 +466,8 @@ func (d db) deleteExpiredEntries() error {
 		entries_data
 	WHERE
 		id IN (
-			SELECT 
-				id 
+			SELECT
+				id
 			FROM
 				entries
 			WHERE

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -407,8 +407,6 @@ func (d db) DeleteGuestLink(id types.GuestLinkID) error {
 
 // Purge deletes expired entries and clears orphaned rows from the database.
 func (d db) Purge() error {
-	log.Printf("deleting expired entries from database")
-
 	err := d.deleteExpiredEntries()
 	if err != nil {
 		return err


### PR DESCRIPTION
Changes addressing TODO comment in Collector: deletes expired entries more efficiently with single SQL statement instead of deleting them in for loop.