### PR TITLE
Count runes to validate user-controlled strings

### DIFF
--- a/handlers/guest_links.go
+++ b/handlers/guest_links.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 	"github.com/mtlynch/picoshare/v2/handlers/parse"
@@ -108,7 +109,7 @@ func guestLinkFromRequest(r *http.Request) (types.GuestLink, error) {
 func parseLabel(label string) (types.GuestLinkLabel, error) {
 	// Arbitrary limit to prevent too-long labels
 	limit := 200
-	if len(label) > limit {
+	if utf8.RuneCountInString(label) > limit {
 		return types.GuestLinkLabel(""), fmt.Errorf("label too long - limit %d characters", limit)
 	}
 

--- a/handlers/parse/file_note.go
+++ b/handlers/parse/file_note.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"errors"
 	"regexp"
+	"unicode/utf8"
 
 	"github.com/mtlynch/picoshare/v2/types"
 )
@@ -20,7 +21,7 @@ func FileNote(s string) (types.FileNote, error) {
 	if s == "" {
 		return types.FileNote{}, nil
 	}
-	if len(s) > MaxFileNoteLen {
+	if utf8.RuneCountInString(s) > MaxFileNoteLen {
 		return types.FileNote{}, errors.New("note is too long")
 	}
 	if err := checkJavaScriptNullOrUndefined(s); err != nil {

--- a/handlers/parse/file_note_test.go
+++ b/handlers/parse/file_note_test.go
@@ -22,6 +22,18 @@ func TestFileNote(t *testing.T) {
 			output:      makeFileNote("Shared with my college group chat"),
 		},
 		{
+			description: "message of maximum length",
+			input:       strings.Repeat("A", parse.MaxFileNoteLen),
+			valid:       true,
+			output:      makeFileNote(strings.Repeat("A", parse.MaxFileNoteLen)),
+		},
+		{
+			description: "message of maximum length with multibyte Unicode characters",
+			input:       strings.Repeat("Ö", parse.MaxFileNoteLen),
+			valid:       true,
+			output:      makeFileNote(strings.Repeat("Ö", parse.MaxFileNoteLen)),
+		},
+		{
 			description: "empty note",
 			input:       "",
 			valid:       true,

--- a/handlers/parse/filename.go
+++ b/handlers/parse/filename.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"errors"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/mtlynch/picoshare/v2/types"
 )
@@ -22,7 +23,7 @@ func Filename(s string) (types.Filename, error) {
 	if s == "" {
 		return types.Filename(""), ErrFilenameEmpty
 	}
-	if len(s) > MaxFilenameLen {
+	if utf8.RuneCountInString(s) > MaxFilenameLen {
 		return types.Filename(""), ErrFilenameTooLong
 	}
 	if s == "." || strings.HasPrefix(s, "..") {

--- a/handlers/parse/filename_test.go
+++ b/handlers/parse/filename_test.go
@@ -23,6 +23,18 @@ func TestFilename(t *testing.T) {
 			err:         nil,
 		},
 		{
+			description: "filename that's the maximum length",
+			input:       strings.Repeat("A", parse.MaxFilenameLen),
+			output:      types.Filename(strings.Repeat("A", parse.MaxFilenameLen)),
+			err:         nil,
+		},
+		{
+			description: "filename that's the maximum length with multibyte Unicode characters",
+			input:       strings.Repeat("Ö", parse.MaxFilenameLen),
+			output:      types.Filename(strings.Repeat("Ö", parse.MaxFilenameLen)),
+			err:         nil,
+		},
+		{
 			description: "empty filename",
 			input:       "",
 			err:         parse.ErrFilenameEmpty,


### PR DESCRIPTION
len(s) gives you the byte count rather than the character count, so this fixes the mistake.

We don't apply this check to entry IDs because they can only be single-byte characters.