### PR TITLE
Only apply Litestream pragmas when Litestream is enabled

### DIFF
--- a/cmd/picoshare/main.go
+++ b/cmd/picoshare/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	ensureDirExists(filepath.Dir(*dbPath))
 
-	store := sqlite.New(*dbPath)
+	store := sqlite.New(*dbPath, isLitestreamEnabled())
 
 	collector := garbagecollect.NewCollector(store, *vacuumDb)
 	gc := garbagecollect.NewScheduler(&collector, 7*time.Hour)
@@ -67,4 +67,8 @@ func ensureDirExists(dir string) {
 			panic(err)
 		}
 	}
+}
+
+func isLitestreamEnabled() bool {
+	return os.Getenv("LITESTREAM_BUCKET") != ""
 }

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -44,7 +44,10 @@ func NewWithChunkSize(path string, chunkSize int, optimizeForLitestream bool) st
 		log.Fatalln(err)
 	}
 
-	if _, err := ctx.Exec("PRAGMA temp_store = FILE"); err != nil {
+	if _, err := ctx.Exec(`
+		PRAGMA temp_store = FILE;
+		PRAGMA journal_mode = WAL;
+		`); err != nil {
 		log.Fatalf("failed to set pragmas: %v", err)
 	}
 
@@ -53,7 +56,6 @@ func NewWithChunkSize(path string, chunkSize int, optimizeForLitestream bool) st
 			-- Apply Litestream recommendations: https://litestream.io/tips/
 			PRAGMA busy_timeout = 5000;
 			PRAGMA synchronous = NORMAL;
-			PRAGMA journal_mode = WAL;
 			PRAGMA wal_autocheckpoint = 0;
 				`); err != nil {
 			log.Fatalf("failed to set Litestream compatibility pragmas: %v", err)

--- a/store/test_sqlite/db.go
+++ b/store/test_sqlite/db.go
@@ -8,12 +8,14 @@ import (
 	"github.com/mtlynch/picoshare/v2/store/sqlite"
 )
 
+const optimizeForLitestream = false
+
 func New() store.Store {
-	return sqlite.New(ephemeralDbURI())
+	return sqlite.New(ephemeralDbURI(), optimizeForLitestream)
 }
 
 func NewWithChunkSize(chunkSize int) store.Store {
-	return sqlite.NewWithChunkSize(ephemeralDbURI(), chunkSize)
+	return sqlite.NewWithChunkSize(ephemeralDbURI(), chunkSize, optimizeForLitestream)
 }
 
 func ephemeralDbURI() string {


### PR DESCRIPTION
Litestream has a set of SQLite pragmas it recommends, but we should only apply them when we're actually using Litestream. Otherwise, we should stick with the SQLite defaults.

Related: #341 