### PR TITLE
Prefer image clipboard types to other data types

### DIFF
--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -52,6 +52,14 @@ function populateEditButton(entryId) {
 // user wants to upload.
 function sortClipboardItems(items) {
   return items.sort((a, b) => {
+    // Prioritize images ahead of other formats.
+    if (a.type.startsWith("image") && !b.type.startsWith("image")) {
+      return -1;
+    }
+    if (b.type.startsWith("image") && !a.type.startsWith("image")) {
+      return 1;
+    }
+
     if (a.kind === "string" && b.kind === "string") {
       // Prefer text/plain strings ahead of other string types.
       return a.type === "text/plain" ? -1 : 1;

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -53,10 +53,13 @@ function populateEditButton(entryId) {
 function sortClipboardItems(items) {
   return items.sort((a, b) => {
     // Prioritize images ahead of other formats.
-    if (a.type.startsWith("image") && !b.type.startsWith("image")) {
+    const isImage = (x) => {
+      x.type.startsWith("image");
+    };
+    if (isImage(a) && !isImage(b)) {
       return -1;
     }
-    if (b.type.startsWith("image") && !a.type.startsWith("image")) {
+    if (isImage(b) && !isImage(a)) {
       return 1;
     }
 


### PR DESCRIPTION
If the user pastes from clipboard and the clipboard data is available in multiple formats, we should prefer image formats ahead of other formats.

Fixes #350