### PR TITLE
Replace ! in routes with -

### DIFF
--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -53,6 +53,10 @@ func (s *Server) routes() {
 	views.Use(upgradeToHttps)
 	views.Use(enforceContentSecurityPolicy)
 	views.HandleFunc("/login", s.authGet()).Methods(http.MethodGet)
+	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	// Legacy routes for entries. We stopped using them because the ! has
+	// unintended side effects within the bash shell.
 	views.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	views.PathPrefix("/!{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	views.PathPrefix("/g/{guestLinkID}").HandlerFunc(s.guestUploadGet()).Methods(http.MethodGet)

--- a/handlers/templates/pages/file-index.html
+++ b/handlers/templates/pages/file-index.html
@@ -28,7 +28,7 @@
         {{ range .Files }}
           <tr test-data-filename="{{ .Filename }}">
             <td class="is-vcentered" test-data-id="filename">
-              <a href="/!{{ .ID }}">{{ .Filename }}</a>
+              <a href="/-{{ .ID }}">{{ .Filename }}</a>
             </td>
             <td class="is-vcentered">
               {{ if .Note.Value }}

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -152,7 +152,7 @@ func (s Server) guestEntryPost() http.HandlerFunc {
 			respondJSON(w, EntryPostResponse{ID: string(id)})
 		} else {
 			w.Header().Set("Content-Type", "text/plain")
-			if _, err := fmt.Fprintf(w, "%s/!%s\r\n", baseURLFromRequest(r), string(id)); err != nil {
+			if _, err := fmt.Fprintf(w, "%s/-%s\r\n", baseURLFromRequest(r), string(id)); err != nil {
 				log.Fatalf("failed to write HTTP response: %v", err)
 			}
 		}

--- a/static/js/lib/links.js
+++ b/static/js/lib/links.js
@@ -1,5 +1,5 @@
 export function makeShortLink(fileId) {
-  return `${window.location.origin}/!${fileId}`;
+  return `${window.location.origin}/-${fileId}`;
 }
 
 export function makeVerboseLink(fileId, filename) {


### PR DESCRIPTION
The ! is a bash special character, which messes things up when you paste PicoShare URLs in the terminal. It's easier to use dash, which isn't a special character for any major filesystem or shell.