### PR TITLE
Revert workaround for CSP on Firefox

### DIFF
--- a/handlers/csp.go
+++ b/handlers/csp.go
@@ -43,6 +43,10 @@ func enforceContentSecurityPolicy(next http.Handler) http.Handler {
 				values: []string{
 					"'self'",
 					"'nonce-" + nonce + "'",
+					// Firefox refuses to load an inline <style> tag in an HTML custom
+					// element, even if we specify a nonce:
+					// https://github.com/mtlynch/picoshare/issues/249
+					"unsafe-inline",
 				},
 			},
 		}


### PR DESCRIPTION
Reverts changes related to  aa0f0daaa7bfae35564d8f285f0ae462e823fd83