### PR TITLE
docker-entrypoint: exec & allowing server to handle signals

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -57,8 +57,8 @@ if [[ "${IS_LITESTREAM_ENABLED}" == 'true' ]]; then
   fi
 
   # Let Litestream start PicoShare as a child process
-  /app/litestream replicate -exec "$PS_LAUNCH_CMD"
+  exec /app/litestream replicate -exec "$PS_LAUNCH_CMD"
 else
   echo "Starting without litestream"
-  eval "${PS_LAUNCH_CMD}"
+  eval "exec ${PS_LAUNCH_CMD}"
 fi


### PR DESCRIPTION
follow [PR398](https://github.com/mtlynch/picoshare/pull/398)

i'm sorry for that i didn't take an eye on Docker entrypoint.

as [this answer](https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash/196053#196053) point out

>Bash does not forward signals like SIGTERM to processes it is currently waiting on. If you want to end your script by segueing into your server (allowing it to handle signals and anything else, as if you had started the server directly), you should use exec, which will replace the shell with the process being opened

so before this PR processes in container are
```
/bin/bash /app/docker-entrypoint -db /data/store.db  (won't forward signals to child
  |
  +---> /app/litestream replicate -exec /app/picoshare -db /data/store.db (will forward signals to child
              |
              +---> /app/picoshare -db /data/store.db
```
after are
```
/app/litestream replicate -exec /app/picoshare -db /data/store.db  (will forward signals to child
              |
              +---> /app/picoshare -db /data/store.db
```

still, bash won't   forward signals  `/app/litestream restore`. adding support for it should introduce these lines of codes
```
# === funcs for forwarding signals to child process in Bash
prep_term()
{
    unset TERM_CHILD_PID
    unset TERM_KILL_NEEDED
    trap 'handle_term' TERM INT
}

handle_term()
{
    if [ "${TERM_CHILD_PID}" ]; then
        kill -TERM "${TERM_CHILD_PID}" 2>/dev/null
    else
        TERM_KILL_NEEDED="yes"
    fi
}

wait_term()
{
    TERM_CHILD_PID=$!
    if [ "${TERM_KILL_NEEDED+x}" ]; then
        kill -TERM "${TERM_CHILD_PID}" 2>/dev/null 
    fi
    wait ${TERM_CHILD_PID} 2>/dev/null
    trap - TERM INT
    wait ${TERM_CHILD_PID} 2>/dev/null
}
# === funcs for forwarding signals to child process in Bash
......
# Restore database from remote storage.
prep_term
/app/litestream restore -if-replica-exists -v "${DB_PATH}" &
wait_term
```
it will make the docker-entrypoint shell file bit of complicate.

for simplicity i think this PR this OK, and it will cover most scenarios.