### PR TITLE
Use a separate SQLite database during e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,8 @@ const config: PlaywrightTestConfig = {
   outputDir: "e2e-results/",
 
   webServer: {
-    command: "PS_SHARED_SECRET=dummypass PORT=6001 ./bin/picoshare",
+    command:
+      "PS_SHARED_SECRET=dummypass PORT=6001 ./bin/picoshare -db data/store-e2e.db",
     port: 6001,
   },
 };


### PR DESCRIPTION
Otherwise the dev database could interfere with the e2e database.