### PR TITLE
Broaden glob pattern for reset-db

### DIFF
--- a/dev-scripts/reset-db
+++ b/dev-scripts/reset-db
@@ -7,6 +7,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 readonly SCRIPT_DIR
 cd "${SCRIPT_DIR}/.."
 
-readonly DB_PATH="data/store.db"
-
-rm ${DB_PATH}* || true
+rm "data/store*.db*" || true


### PR DESCRIPTION
When I added another database in f35ff388c74f17042e7491cb9e3dee6d2aa9e23d, I forgot to update the reset DB pattern to match.