### PR TITLE
Skip backblaze upload on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,14 +107,25 @@ jobs:
       - run:
           name: Run end-to-end tests
           command: ./dev-scripts/run-e2e-tests --skip-build
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - ./playwright-report
       - store_artifacts:
           path: playwright-report
-      # Playwright's artifacts don't render correctly in CircleCI, so upload an
-      # extra copy to Backblaze.
-      # https://github.com/microsoft/playwright/issues/18108
+  # Playwright's artifacts don't render correctly in CircleCI, so upload an
+  # extra copy to Backblaze.
+  # https://github.com/microsoft/playwright/issues/18108
+  e2e_results_to_cloud:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      BACKBLAZE_BUCKET: picoshare-e2e-artifacts
+    steps:
+      - attach_workspace:
+          at: ./
       - run:
           name: Download backblaze CLI tool
-          when: always
           command: |
             wget https://github.com/Backblaze/B2_Command_Line_Tool/releases/latest/download/b2-linux && \
             mv b2-linux b2 && \
@@ -122,17 +133,14 @@ jobs:
             ./b2 version
       - run:
           name: Authorize Backblaze CLI tool
-          when: always
           command: |
             set -u
             ./b2 authorize-account "${BACKBLAZE_KEY_ID}" "${BACKBLAZE_KEY}"
       - run:
           name: Upload artifacts to backblaze bucket
-          when: always
           command: ./b2 sync ./playwright-report "b2://${BACKBLAZE_BUCKET}/artifacts/${CIRCLE_SHA1}/playwright-report"
       - run:
           name: Print public URLs of images
-          when: always
           command: |
             echo "Uploaded images to:"
             echo "https://f002.backblazeb2.com/file/${BACKBLAZE_BUCKET}/artifacts/${CIRCLE_SHA1}/playwright-report/index.html"
@@ -239,6 +247,16 @@ workflows:
               only: /.*/
           requires:
             - build_backend
+      - e2e_results_to_cloud:
+          filters:
+            branches:
+              # Skip forked PRs, as they don't have access to cloud storage
+              # credentials.
+              ignore: /pull\/[0-9]+/
+            tags:
+              only: /.*/
+          requires:
+            - e2e
       - build_docker_images:
           requires:
             - check_whitespace


### PR DESCRIPTION
Forked PRs don't have access to environment variables, so the upload will fail.