### PR TITLE
Infer content type when it wasn't specified at upload time

### DIFF
--- a/handlers/download.go
+++ b/handlers/download.go
@@ -48,6 +48,8 @@ func (s Server) entryGet() http.HandlerFunc {
 }
 
 func inferContentTypeFromFilename(f picoshare.Filename) (picoshare.ContentType, error) {
+	// For files that modern browser can play natively, infer the content type if
+	// none was specified at upload time.
 	switch filepath.Ext(f.String()) {
 	case ".mp4":
 		return picoshare.ContentType("video/mp4"), nil

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -34,10 +34,24 @@ func TestEntryGet(t *testing.T) {
 			expectedContentType:        "audio/mpeg",
 		},
 		{
+			description:                "retrieves audio entry and infers content-type when it wasn't specified at upload time",
+			requestRoute:               "/-AAAAAAAA22",
+			expectedStatus:             http.StatusOK,
+			expectedContentDisposition: `filename="test0.mp3"`,
+			expectedContentType:        "audio/mpeg",
+		},
+		{
 			description:                "retrieves video entry",
 			requestRoute:               "/-VVVVVVVVVV",
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test.mp4"`,
+			expectedContentType:        "video/mp4",
+		},
+		{
+			description:                "retrieves video entry and infers content-type when it wasn't specified at upload time",
+			requestRoute:               "/-VVVVVVVV22",
+			expectedStatus:             http.StatusOK,
+			expectedContentDisposition: `filename="test0.mp4"`,
 			expectedContentType:        "video/mp4",
 		},
 		{
@@ -67,6 +81,13 @@ func TestEntryGet(t *testing.T) {
 				},
 				Reader: strings.NewReader("dummy audio contents"),
 			}
+			dummyAudioEntrywithoutContentType := picoshare.UploadEntry{
+				UploadMetadata: picoshare.UploadMetadata{
+					ID:       "AAAAAAAA22",
+					Filename: picoshare.Filename("test0.mp3"),
+				},
+				Reader: strings.NewReader("dummy audio contents"),
+			}
 			dummyVideoEntry := picoshare.UploadEntry{
 				UploadMetadata: picoshare.UploadMetadata{
 					ID:          "VVVVVVVVVV",
@@ -75,7 +96,20 @@ func TestEntryGet(t *testing.T) {
 				},
 				Reader: strings.NewReader("dummy video contents"),
 			}
-			for _, entry := range []picoshare.UploadEntry{dummyTextEntry, dummyAudioEntry, dummyVideoEntry} {
+			dummyVideoEntryWithoutContentType := picoshare.UploadEntry{
+				UploadMetadata: picoshare.UploadMetadata{
+					ID:       "VVVVVVVV22",
+					Filename: picoshare.Filename("test0.mp4"),
+				},
+				Reader: strings.NewReader("dummy video contents"),
+			}
+			for _, entry := range []picoshare.UploadEntry{
+				dummyTextEntry,
+				dummyAudioEntry,
+				dummyAudioEntrywithoutContentType,
+				dummyVideoEntry,
+				dummyVideoEntryWithoutContentType,
+			} {
 				if err := dataStore.InsertEntry(entry.Reader, entry.UploadMetadata); err != nil {
 					panic(err)
 				}

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -35,6 +35,10 @@ type (
 // Treat a distant expiration time as sort of a sentinel value signifying a "never expire" option.
 var NeverExpire = ExpirationTime(time.Date(2999, time.December, 31, 0, 0, 0, 0, time.UTC))
 
+func (f Filename) String() string {
+	return string(f)
+}
+
 func (et ExpirationTime) String() string {
 	return (time.Time(et)).String()
 }


### PR DESCRIPTION
Resolves #427 

If the client didn't specify the content type for a file at upload time, we can try to infer it based on the filename. This is helpful for files like mp4s or mp3s that modern browsers can play natively instead of relying on the user to download it and find a client player.