### PR TITLE
Remove error return type from handlers.New

### DIFF
--- a/cmd/picoshare/main.go
+++ b/cmd/picoshare/main.go
@@ -46,10 +46,7 @@ func main() {
 	gc := garbagecollect.NewScheduler(&collector, 7*time.Hour)
 	gc.StartAsync()
 
-	server, err := handlers.New(authenticator, store, spaceChecker, &collector)
-	if err != nil {
-		panic(err)
-	}
+	server := handlers.New(authenticator, store, spaceChecker, &collector)
 
 	h := gorilla.LoggingHandler(os.Stdout, server.Router())
 	if os.Getenv("PS_BEHIND_PROXY") != "" {

--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -23,11 +23,7 @@ func TestDeleteExistingFile(t *testing.T) {
 		picoshare.UploadMetadata{
 			ID: picoshare.EntryID("hR87apiUCj"),
 		})
-
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/entry/hR87apiUCj", nil)
 	if err != nil {
@@ -50,11 +46,7 @@ func TestDeleteExistingFile(t *testing.T) {
 
 func TestDeleteNonExistentFile(t *testing.T) {
 	dataStore := test_sqlite.New()
-
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/entry/hR87apiUCj", nil)
 	if err != nil {
@@ -73,11 +65,7 @@ func TestDeleteNonExistentFile(t *testing.T) {
 
 func TestDeleteInvalidEntryID(t *testing.T) {
 	dataStore := test_sqlite.New()
-
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/entry/invalid-entry-id", nil)
 	if err != nil {

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -115,10 +115,7 @@ func TestEntryGet(t *testing.T) {
 				}
 			}
 
-			s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 			req, err := http.NewRequest("GET", tt.requestRoute, nil)
 			if err != nil {

--- a/handlers/guest_links_test.go
+++ b/handlers/guest_links_test.go
@@ -55,11 +55,7 @@ func TestGuestLinksPostAcceptsValidRequest(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-
-			s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 			req, err := http.NewRequest("POST", "/api/guest-links", strings.NewReader(tt.payload))
 			if err != nil {
@@ -211,11 +207,7 @@ func TestGuestLinksPostRejectsInvalidRequest(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-
-			s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 			req, err := http.NewRequest("POST", "/api/guest-links", strings.NewReader(tt.payload))
 			if err != nil {
@@ -250,10 +242,7 @@ func TestDeleteExistingGuestLink(t *testing.T) {
 		Expires: mustParseExpirationTime("2030-01-02T03:04:25Z"),
 	})
 
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/abcdefgh23456789", nil)
 	if err != nil {
@@ -275,11 +264,7 @@ func TestDeleteExistingGuestLink(t *testing.T) {
 
 func TestDeleteNonExistentGuestLink(t *testing.T) {
 	dataStore := test_sqlite.New()
-
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/abcdefgh23456789", nil)
 	if err != nil {
@@ -298,11 +283,7 @@ func TestDeleteNonExistentGuestLink(t *testing.T) {
 
 func TestDeleteInvalidGuestLink(t *testing.T) {
 	dataStore := test_sqlite.New()
-
-	s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/i-am-an-invalid-link", nil)
 	if err != nil {

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -26,7 +26,7 @@ func (s Server) Router() *mux.Router {
 
 // New creates a new server with all the state it needs to satisfy HTTP
 // requests.
-func New(authenticator auth.Authenticator, store store.Store, spaceChecker space.Checker, collector *garbagecollect.Collector) (Server, error) {
+func New(authenticator auth.Authenticator, store store.Store, spaceChecker space.Checker, collector *garbagecollect.Collector) Server {
 	s := Server{
 		router:        mux.NewRouter(),
 		authenticator: authenticator,
@@ -36,5 +36,5 @@ func New(authenticator auth.Authenticator, store store.Store, spaceChecker space
 	}
 
 	s.routes()
-	return s, nil
+	return s
 }

--- a/handlers/settings_test.go
+++ b/handlers/settings_test.go
@@ -56,11 +56,7 @@ func TestSettingsPut(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-
-			s, err := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, dataStore, nilSpaceChecker, nilGarbageCollector)
 
 			req, err := http.NewRequest("PUT", "/api/settings", strings.NewReader(tt.payload))
 			if err != nil {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -94,10 +94,7 @@ func TestEntryPost(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			store := test_sqlite.New()
-			s, err := handlers.New(mockAuthenticator{}, store, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, store, nilSpaceChecker, nilGarbageCollector)
 
 			formData, contentType := createMultipartFormBody(tt.filename, tt.note, bytes.NewBuffer([]byte(tt.contents)))
 
@@ -229,10 +226,7 @@ func TestEntryPut(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			store := test_sqlite.New()
 			store.InsertEntry(strings.NewReader(("dummy data")), originalEntry)
-			s, err := handlers.New(mockAuthenticator{}, store, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(mockAuthenticator{}, store, nilSpaceChecker, nilGarbageCollector)
 
 			req, err := http.NewRequest("PUT", "/api/entry/"+tt.targetID, strings.NewReader(tt.payload))
 			if err != nil {
@@ -386,10 +380,7 @@ func TestGuestUpload(t *testing.T) {
 				}
 			}
 
-			s, err := handlers.New(authenticator, store, nilSpaceChecker, nilGarbageCollector)
-			if err != nil {
-				t.Fatal(err)
-			}
+			s := handlers.New(authenticator, store, nilSpaceChecker, nilGarbageCollector)
 
 			filename := "dummyimage.png"
 			contents := "dummy bytes"


### PR DESCRIPTION
It can't fail, so there's no point in returning an error type.