### PR TITLE
Infer mp3/mp4 content type when client specifies octet-stream

### DIFF
--- a/handlers/download.go
+++ b/handlers/download.go
@@ -36,7 +36,7 @@ func (s Server) entryGet() http.HandlerFunc {
 		}
 
 		contentType := entry.ContentType
-		if contentType == "" {
+		if contentType == "" || contentType == "application/octet-stream" {
 			if inferred, err := inferContentTypeFromFilename(entry.Filename); err == nil {
 				contentType = inferred
 			}

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -37,9 +37,10 @@ var (
 		Filename:    picoshare.Filename("test.mp4"),
 		ContentType: picoshare.ContentType("video/mp4"),
 	}
-	dummyVideoEntryWithoutContentType = mockEntry{
-		ID:       "VVVVVVVV22",
-		Filename: picoshare.Filename("test0.mp4"),
+	dummyVideoEntryWithGenericContentType = mockEntry{
+		ID:          "VVVVVVVV22",
+		Filename:    picoshare.Filename("test0.mp4"),
+		ContentType: picoshare.ContentType("application/octet-stream"),
 	}
 )
 
@@ -100,7 +101,7 @@ func TestEntryGet(t *testing.T) {
 				dummyAudioEntry,
 				dummyAudioEntrywithoutContentType,
 				dummyVideoEntry,
-				dummyVideoEntryWithoutContentType,
+				dummyVideoEntryWithGenericContentType,
 			} {
 				entry := picoshare.UploadEntry{
 					UploadMetadata: picoshare.UploadMetadata{


### PR DESCRIPTION
curl specifies a Content-Type of application/octet-stream for mp3 and mp4 files, so this treats those the same as missing content type files and infers a better content type.