### PR TITLE
Refactor e2e tests to click menu items by role

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -3,17 +3,16 @@ import { test, expect } from "@playwright/test";
 test("logs in and logs out", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByTestId("log-in").click();
+  await page.getByRole("menuitem", { name: "Log In" }).click();
 
   await expect(page).toHaveURL("/login");
   await page.locator("form input[type='password']").fill("dummypass");
   await page.locator("form input[type='submit']").click();
 
   await expect(page).toHaveURL("/");
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("#navbar-log-out").click();
 
-  await expect(
-    page.locator(".navbar-item .button[data-testid='log-in']")
-  ).toBeVisible();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Log Out" }).click();
+
+  await expect(page.getByRole("menuitem", { name: "Log In" })).toBeVisible();
 });

--- a/e2e/guest-links.spec.ts
+++ b/e2e/guest-links.spec.ts
@@ -4,7 +4,7 @@ import { login } from "./helpers/login.js";
 test("creates a guest link and uploads a file as a guest", async ({ page }) => {
   await login(page);
 
-  await page.locator("nav .navbar-item[href='/guest-links']").click();
+  await page.getByRole("menuitem", { name: "Guest Links" }).click();
 
   await page.locator(".content .button.is-primary").click();
 
@@ -28,8 +28,8 @@ test("creates a guest link and uploads a file as a guest", async ({ page }) => {
   expect(guestLinkRouteValue).not.toBeNull();
   const guestLinkRoute = String(guestLinkRouteValue);
 
-  await page.locator(".navbar-end .navbar-item.is-hoverable").hover();
-  await page.locator("#navbar-log-out").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Log Out" }).click();
 
   await expect(page).toHaveURL("/");
   await page.goto(guestLinkRoute);

--- a/e2e/helpers/login.js
+++ b/e2e/helpers/login.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 
 export async function login(page) {
   await page.goto("/");
-  await page.getByTestId("log-in").click();
+  await page.getByRole("menuitem", { name: "Log In" }).click();
 
   await expect(page).toHaveURL("/login");
   await page.locator("form input[type='password']").fill("dummypass");

--- a/e2e/paste.spec.ts
+++ b/e2e/paste.spec.ts
@@ -38,7 +38,7 @@ test("pastes text in the upload input", async ({ page }) => {
     page.locator("#upload-result upload-links #short-link-box #link")
   ).toBeVisible();
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(".table tbody tr:first-child [test-data-id='filename']")
   ).toHaveText(/pasted-.*/);

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -4,8 +4,8 @@ import { login } from "./helpers/login.js";
 test("default file expiration is 30 days", async ({ page }) => {
   await login(page);
 
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await expect(
@@ -26,8 +26,8 @@ test("default file expiration is 30 days", async ({ page }) => {
 test("changes default file expiration to 5 days", async ({ page }) => {
   await login(page);
 
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await expect(
@@ -48,8 +48,8 @@ test("changes default file expiration to 5 days", async ({ page }) => {
 test("changes default file expiration to 1 year", async ({ page }) => {
   await login(page);
 
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await expect(
@@ -83,8 +83,8 @@ test("changes default file expiration to 1 year", async ({ page }) => {
 test("changes default file expiration to 10 years", async ({ page }) => {
   await login(page);
 
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await expect(
@@ -107,8 +107,8 @@ test("changes default file expiration to 10 years", async ({ page }) => {
 test("changes default file expiration to never", async ({ page }) => {
   await login(page);
 
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await page.getByRole("checkbox", { name: "Store files forever" }).check();

--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -31,7 +31,7 @@ test("uploads a file without specifying any parameters", async ({
   // Verify that cleanup doesn't incorrectly remove the file.
   await request.post("/api/debug/db/cleanup");
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
       ".table tr[test-data-filename='simple-upload.txt'] [test-data-id='filename']"
@@ -64,7 +64,7 @@ test("uploads a file with a custom expiration time", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
       ".table tr[test-data-filename='custom-expiration-upload.txt'] [test-data-id='filename']"
@@ -99,7 +99,7 @@ test("uploads a file with a note", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
       ".table tr[test-data-filename='upload-with-note.txt'] [test-data-id='filename']"
@@ -126,7 +126,7 @@ test("uploads a file and deletes it", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await page
     .locator(
       ".table tr[test-data-filename='upload-for-deletion.txt'] [pico-purpose='edit']"
@@ -151,8 +151,8 @@ test("uploads a file and then uploads another", async ({ page }) => {
   await login(page);
 
   // Set default to 30 days.
-  await page.getByTestId("system-dropdown").hover();
-  await page.locator("a[href='/settings']").click();
+  await page.getByRole("menuitem", { name: "System" }).hover();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL("/settings");
 
   await page.locator("#default-expiration").fill("30");
@@ -186,7 +186,7 @@ test("uploads a file and then uploads another", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
 
   await expect(page).toHaveURL("/files");
   await expect(
@@ -217,7 +217,7 @@ test("uploads a file and deletes its note", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await page
     .locator(
       ".table tr[test-data-filename='upload-with-temporary-note.txt'] [pico-purpose='edit']"
@@ -252,7 +252,7 @@ test("uploads a file and edits its note", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await page
     .locator(
       ".table tr[test-data-filename='upload-with-note-i-will-edit.txt'] [pico-purpose='edit']"
@@ -285,7 +285,7 @@ test("uploads a file and changes its expiration time", async ({ page }) => {
     "Upload complete!"
   );
 
-  await page.locator(".navbar a[href='/files']").click();
+  await page.getByRole("menuitem", { name: "Files" }).click();
   await page
     .locator(
       ".table tr[test-data-filename='file-with-new-expiration.txt'] [pico-purpose='edit']"

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -21,28 +21,42 @@
             <div class="navbar-item">
               <a
                 class="button is-primary is-success"
+                role="menuitem"
                 href="/"
                 data-testid="upload-btn"
                 >Upload</a
               >
             </div>
-            <a class="navbar-item" href="/files">Files</a>
-            <a class="navbar-item" href="/guest-links">Guest Links</a>
+            <a class="navbar-item" role="menuitem" href="/files">Files</a>
+            <a class="navbar-item" role="menuitem" href="/guest-links"
+              >Guest Links</a
+            >
           </div>
         {{ end }}
         <div class="navbar-end">
           {{ if .IsAuthenticated }}
             <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link" data-testid="system-dropdown">System</a>
+              <a
+                class="navbar-link"
+                role="menuitem"
+                data-testid="system-dropdown"
+                >System</a
+              >
               <div class="navbar-dropdown">
-                <a class="navbar-item" href="/settings">Settings</a>
-                <a class="navbar-item" href="/disk-usage">Disk Usage</a>
-                <a class="navbar-item" id="navbar-log-out">Log Out</a>
+                <a class="navbar-item" role="menuitem" href="/settings"
+                  >Settings</a
+                >
+                <a class="navbar-item" role="menuitem" href="/disk-usage"
+                  >Disk Usage</a
+                >
+                <a id="navbar-log-out" class="navbar-item" role="menuitem"
+                  >Log Out</a
+                >
               </div>
             </div>
           {{ else }}
             <div class="navbar-item">
-              <a class="button is-primary" data-testid="log-in" href="/login">
+              <a class="button is-primary" role="menuitem" href="/login">
                 Log In
               </a>
             </div>


### PR DESCRIPTION
Instead of using hrefs, IDs, or test IDs, we should use ARIA roles and text, as it's closer to how real users navigate the site.