### PR TITLE
Give playwright its own package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,12 @@ jobs:
           at: ./
       - run:
           name: Install dependencies
-          command: npm install
+          command: cd e2e && npm install
       - run:
           name: Run end-to-end tests
           command: ./dev-scripts/run-e2e-tests --skip-build
       - store_artifacts:
-          path: playwright-report
+          path: e2e/playwright-report
   build_docker_images:
     docker:
       - image: cimg/base:stable

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     ],
   },
   ignorePatterns: [
-    "playwright-report/*",
+    "e2e/playwright-report/*",
     "handlers/static/third-party/**/*.js",
   ],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ node_modules/
 .DS_Store
 
 # Playwright output
-/playwright-report/
+/e2e/playwright-report/
 /playwright/.cache/
-/e2e-results/
+e2e/results/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
-playwright-report/
+e2e/playwright-report/
 handlers/static/third-party
 .coverage.html

--- a/dev-scripts/run-e2e-tests
+++ b/dev-scripts/run-e2e-tests
@@ -25,4 +25,5 @@ if [[ "${REBUILD}" == "true" ]]; then
   ./dev-scripts/build-backend dev
 fi
 
+cd e2e
 npx playwright test "$@"

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "picoshare-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@playwright/test": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.1"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+          "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
+          "dev": true
+        }
+      }
+    },
+    "@types/node": {
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+          "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "picoshare-e2e",
+  "version": "1.0.0",
+  "description": "PicoShare e2e",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mtlynch/picoshare.git"
+  },
+  "author": "Michael Lynch",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/mtlynch/picoshare/issues"
+  },
+  "homepage": "https://pico.rocks",
+  "devDependencies": {
+    "@playwright/test": "1.32.1",
+    "isomorphic-fetch": "^3.0.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
-  testDir: "./e2e",
+  testDir: "./",
   timeout: 35 * 1000,
   expect: {
     timeout: 5 * 1000,
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
   retries: 0,
   workers: undefined,
   reporter: "html",
-  globalSetup: require.resolve("./e2e/helpers/global-setup"),
+  globalSetup: require.resolve("./helpers/global-setup"),
   use: {
     baseURL: "http://localhost:6001",
     actionTimeout: 0,
@@ -33,10 +33,10 @@ const config: PlaywrightTestConfig = {
     },
   ],
 
-  outputDir: "e2e-results/",
+  outputDir: "results/",
 
   webServer: {
-    command: "PS_SHARED_SECRET=dummypass PORT=6001 ./bin/picoshare-dev",
+    command: "PS_SHARED_SECRET=dummypass PORT=6001 ../bin/picoshare-dev",
     port: 6001,
   },
 };


### PR DESCRIPTION
We want to install mocha in the other package.json file, and the two don't get along. mocha needs us to set type='module' and playwright needs us *not* to set type='module'.