### PR TITLE
Change HTML test ID attribute name to data-testid

### DIFF
--- a/e2e/guest-links.spec.ts
+++ b/e2e/guest-links.spec.ts
@@ -16,7 +16,7 @@ test("creates a guest link and uploads a file as a guest", async ({ page }) => {
 
   await expect(page).toHaveURL("/guest-links");
   const guestLinkElement = page.locator(
-    '.table tbody tr:first-child td[test-data-id="guest-link-label"] a',
+    '.table tbody tr:first-child td[data-testid="guest-link-label"] a',
     {
       hasText: "For e2e testing",
     }

--- a/e2e/paste.spec.ts
+++ b/e2e/paste.spec.ts
@@ -40,14 +40,14 @@ test("pastes text in the upload input", async ({ page }) => {
 
   await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
-    page.locator(".table tbody tr:first-child [test-data-id='filename']")
+    page.locator(".table tbody tr:first-child [data-testid='filename']")
   ).toHaveText(/pasted-.*/);
   await expect(
-    page.locator(".table tbody tr:first-child [test-data-id='note']")
+    page.locator(".table tbody tr:first-child [data-testid='note']")
   ).toHaveCount(0);
 
   await page
-    .locator(".table tbody tr:first-child [test-data-id='filename'] a")
+    .locator(".table tbody tr:first-child [data-testid='filename'] a")
     .click();
 
   await expect(await page.innerText("body")).toEqual("I'm pasting dummy text!");

--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -34,12 +34,12 @@ test("uploads a file without specifying any parameters", async ({
   await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
-      ".table tr[test-data-filename='simple-upload.txt'] [test-data-id='filename']"
+      ".table tr[test-data-filename='simple-upload.txt'] [data-testid='filename']"
     )
   ).toHaveText("simple-upload.txt");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='simple-upload.txt'] [test-data-id='note']"
+      ".table tr[test-data-filename='simple-upload.txt'] [data-testid='note']"
     )
   ).toHaveCount(0);
 });
@@ -67,18 +67,18 @@ test("uploads a file with a custom expiration time", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
-      ".table tr[test-data-filename='custom-expiration-upload.txt'] [test-data-id='filename']"
+      ".table tr[test-data-filename='custom-expiration-upload.txt'] [data-testid='filename']"
     )
   ).toHaveText("custom-expiration-upload.txt");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='custom-expiration-upload.txt'] [test-data-id='note']"
+      ".table tr[test-data-filename='custom-expiration-upload.txt'] [data-testid='note']"
     )
   ).toHaveCount(0);
 
   await expect(
     page.locator(
-      ".table tr[test-data-filename='custom-expiration-upload.txt'] [test-data-id='expiration']"
+      ".table tr[test-data-filename='custom-expiration-upload.txt'] [data-testid='expiration']"
     )
   ).toHaveText(/^2029-09-03/);
 });
@@ -102,12 +102,12 @@ test("uploads a file with a note", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-with-note.txt'] [test-data-id='filename']"
+      ".table tr[test-data-filename='upload-with-note.txt'] [data-testid='filename']"
     )
   ).toHaveText("upload-with-note.txt");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-with-note.txt'] [test-data-id='note']"
+      ".table tr[test-data-filename='upload-with-note.txt'] [data-testid='note']"
     )
   ).toHaveText("For Pico, with Love and Squalor");
 });
@@ -191,12 +191,12 @@ test("uploads a file and then uploads another", async ({ page }) => {
   await expect(page).toHaveURL("/files");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-1.txt'] td[test-data-id='expiration']"
+      ".table tr[test-data-filename='upload-1.txt'] td[data-testid='expiration']"
     )
   ).toHaveText(/ \(30 days\)$/);
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-2.txt'] td[test-data-id='expiration']"
+      ".table tr[test-data-filename='upload-2.txt'] td[data-testid='expiration']"
     )
   ).toHaveText(/ \(30 days\)$/);
 });
@@ -231,7 +231,7 @@ test("uploads a file and deletes its note", async ({ page }) => {
   await expect(page).toHaveURL("/files");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-with-temporary-note.txt'] [test-data-id='note']"
+      ".table tr[test-data-filename='upload-with-temporary-note.txt'] [data-testid='note']"
     )
   ).toHaveCount(0);
 });
@@ -266,7 +266,7 @@ test("uploads a file and edits its note", async ({ page }) => {
   await expect(page).toHaveURL("/files");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='upload-with-note-i-will-edit.txt'] [test-data-id='note']"
+      ".table tr[test-data-filename='upload-with-note-i-will-edit.txt'] [data-testid='note']"
     )
   ).toHaveText("I have a different note now");
 });
@@ -302,7 +302,7 @@ test("uploads a file and changes its expiration time", async ({ page }) => {
   await expect(page).toHaveURL("/files");
   await expect(
     page.locator(
-      ".table tr[test-data-filename='file-with-new-expiration.txt'] [test-data-id='expiration']"
+      ".table tr[test-data-filename='file-with-new-expiration.txt'] [data-testid='expiration']"
     )
   ).toHaveText(/^2029-09-04/);
 });

--- a/handlers/templates/pages/file-index.html
+++ b/handlers/templates/pages/file-index.html
@@ -109,14 +109,14 @@
       <tbody>
         {{ range .Files }}
           <tr test-data-filename="{{ .Filename }}">
-            <td class="is-vcentered" test-data-id="filename">
+            <td class="is-vcentered" data-testid="filename">
               <a href="/-{{ .ID }}">{{ .Filename }}</a>
             </td>
             <td class="is-vcentered">
               {{ if .Note.Value }}
                 <div class="tooltip">
                   <i class="fa-solid fa-note-sticky mx-auto"></i>
-                  <span class="tooltip-text" test-data-id="note"
+                  <span class="tooltip-text" data-testid="note"
                     >{{ .Note }}</span
                   >
                 </div>
@@ -124,7 +124,7 @@
             </td>
             <td class="is-vcentered">{{ formatFileSize .Size }}</td>
             <td class="is-vcentered">{{ formatDate .Uploaded }}</td>
-            <td class="is-vcentered" test-data-id="expiration">
+            <td class="is-vcentered" data-testid="expiration">
               {{- formatExpiration .Expires -}}
             </td>
             <td class="is-vcentered">

--- a/handlers/templates/pages/guest-link-index.html
+++ b/handlers/templates/pages/guest-link-index.html
@@ -132,7 +132,7 @@
       <tbody>
         {{ range .GuestLinks }}
           <tr {{ if not (isActive .) }}class="inactive"{{ end }}>
-            <td class="is-vcentered" test-data-id="guest-link-label">
+            <td class="is-vcentered" data-testid="guest-link-label">
               {{ if isActive . }}
                 <a href="/g/{{ .ID }}">
                   {{ template "label-formatted" . }}


### PR DESCRIPTION
This changes the test ID attribute in HTML from test-data-id to data-testid, which matches Playwright's conventions (and seems to be more common among other apps).