### PR TITLE
Delete data-testid attributes

### DIFF
--- a/e2e/guest-links.spec.ts
+++ b/e2e/guest-links.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { login } from "./helpers/login.js";
 
+const labelColumn = 0;
+
 test("creates a guest link and uploads a file as a guest", async ({ page }) => {
   await login(page);
 
@@ -15,16 +17,17 @@ test("creates a guest link and uploads a file as a guest", async ({ page }) => {
   await page.getByRole("button", { name: "Create" }).click();
 
   await expect(page).toHaveURL("/guest-links");
-  const guestLinkElement = page.locator(
-    '.table tbody tr:first-child td[data-testid="guest-link-label"] a',
-    {
-      hasText: "For e2e testing",
-    }
-  );
-  expect(guestLinkElement).toBeVisible();
+  const guestLinkRow = await page
+    .getByRole("row")
+    .filter({ hasText: "For e2e testing" });
+  await expect(guestLinkRow).toBeVisible();
 
   // Save the route to the guest link URL so that we can return to it later.
-  const guestLinkRouteValue = await guestLinkElement.getAttribute("href");
+  const guestLinkRouteValue = await guestLinkRow
+    .getByRole("cell")
+    .nth(labelColumn)
+    .getByRole("link")
+    .getAttribute("href");
   expect(guestLinkRouteValue).not.toBeNull();
   const guestLinkRoute = String(guestLinkRouteValue);
 

--- a/e2e/paste.spec.ts
+++ b/e2e/paste.spec.ts
@@ -45,13 +45,17 @@ test("pastes text in the upload input", async ({ page }) => {
     page.getByRole("row").filter({ hasText: /pasted-.*/ })
   ).toBeVisible();
   await expect(
-    page.getByRole("row").getByRole("cell").nth(noteColumn)
+    page
+      .getByRole("row")
+      .filter({ hasText: /pasted-.*/ })
+      .getByRole("cell")
+      .nth(noteColumn)
   ).toBeEmpty();
 
   await page
-    .getByRole("row")
-    .getByRole("button")
-    .filter({ has: page.locator(".fa-edit") })
+    .getByRole("cell")
+    .filter({ hasText: /pasted-.*/ })
+    .getByRole("link")
     .click();
 
   await expect(await page.innerText("body")).toEqual("I'm pasting dummy text!");

--- a/e2e/paste.spec.ts
+++ b/e2e/paste.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { login } from "./helpers/login.js";
 
+const noteColumn = 1;
+
 // Playwright can't yet copy to clipboard, so this is a workaround.
 // https://github.com/microsoft/playwright/issues/15860
 async function clipboardCopy(page, text) {
@@ -40,14 +42,16 @@ test("pastes text in the upload input", async ({ page }) => {
 
   await page.getByRole("menuitem", { name: "Files" }).click();
   await expect(
-    page.locator(".table tbody tr:first-child [data-testid='filename']")
-  ).toHaveText(/pasted-.*/);
+    page.getByRole("row").filter({ hasText: /pasted-.*/ })
+  ).toBeVisible();
   await expect(
-    page.locator(".table tbody tr:first-child [data-testid='note']")
-  ).toHaveCount(0);
+    page.getByRole("row").getByRole("cell").nth(noteColumn)
+  ).toBeEmpty();
 
   await page
-    .locator(".table tbody tr:first-child [data-testid='filename'] a")
+    .getByRole("row")
+    .getByRole("button")
+    .filter({ has: page.locator(".fa-edit") })
     .click();
 
   await expect(await page.innerText("body")).toEqual("I'm pasting dummy text!");

--- a/handlers/templates/pages/file-index.html
+++ b/handlers/templates/pages/file-index.html
@@ -109,22 +109,20 @@
       <tbody>
         {{ range .Files }}
           <tr test-data-filename="{{ .Filename }}">
-            <td class="is-vcentered" data-testid="filename">
+            <td class="is-vcentered">
               <a href="/-{{ .ID }}">{{ .Filename }}</a>
             </td>
             <td class="is-vcentered">
               {{ if .Note.Value }}
                 <div class="tooltip">
                   <i class="fa-solid fa-note-sticky mx-auto"></i>
-                  <span class="tooltip-text" data-testid="note"
-                    >{{ .Note }}</span
-                  >
+                  <span class="tooltip-text">{{ .Note }}</span>
                 </div>
               {{ end }}
             </td>
             <td class="is-vcentered">{{ formatFileSize .Size }}</td>
             <td class="is-vcentered">{{ formatDate .Uploaded }}</td>
-            <td class="is-vcentered" data-testid="expiration">
+            <td class="is-vcentered">
               {{- formatExpiration .Expires -}}
             </td>
             <td class="is-vcentered">
@@ -133,6 +131,7 @@
                   <a
                     class="button is-link"
                     href="/files/{{ .ID }}/edit"
+                    role="button"
                     pico-purpose="edit"
                     pico-entry-id="{{ .ID }}"
                   >

--- a/handlers/templates/pages/guest-link-index.html
+++ b/handlers/templates/pages/guest-link-index.html
@@ -132,7 +132,7 @@
       <tbody>
         {{ range .GuestLinks }}
           <tr {{ if not (isActive .) }}class="inactive"{{ end }}>
-            <td class="is-vcentered" data-testid="guest-link-label">
+            <td class="is-vcentered">
               {{ if isActive . }}
                 <a href="/g/{{ .ID }}">
                   {{ template "label-formatted" . }}


### PR DESCRIPTION
The data-testid attributes are kind of a hack. We can more usefully exercise the UI in e2e tests by using role-based Playwright locators rather than having special test data IDs.