### PR TITLE
Package releases on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,19 +274,23 @@ workflows:
             tags:
               only: /[0-9]+(\.[0-9]+){2}/
             branches:
-              ignore: /.*/
+              only: master
       - publish_release:
           requires:
             - package_release
           filters:
             tags:
-              only: /.*/
+              only: /[0-9]+(\.[0-9]+){2}/
+            branches:
+              ignore: /.*/
       - publish_docker_images:
           requires:
             - package_release
           filters:
             tags:
-              only: /.*/
+              only: /[0-9]+(\.[0-9]+){2}/
+            branches:
+              ignore: /.*/
       - deploy:
           requires:
             - check_whitespace


### PR DESCRIPTION
We should do the packaging step on the master branch so that there are fewer steps that happen only on release.