### PR TITLE
Remove incorrect slot elements in upload-links

### DIFF
--- a/handlers/templates/custom-elements/upload-links.html
+++ b/handlers/templates/custom-elements/upload-links.html
@@ -5,14 +5,10 @@
     }
   </style>
   <div class="box-wrapper">
-    <upload-link-box id="verbose-link-box">
-      <slot>Full Link</slot>
-    </upload-link-box>
+    <upload-link-box id="verbose-link-box">Full Link</upload-link-box>
   </div>
   <div class="box-wrapper">
-    <upload-link-box id="short-link-box">
-      <slot>Shortlink</slot>
-    </upload-link-box>
+    <upload-link-box id="short-link-box">Shortlink</upload-link-box>
   </div>
 </template>
 


### PR DESCRIPTION
For default slots, we don't need to include the slot element, and in some cases, it messes up rendering.