### PR TITLE
Delete pico-purpose attributes

### DIFF
--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -125,7 +125,7 @@ test("uploads a file and deletes it", async ({ page }) => {
     .click();
 
   await expect(page).toHaveURL(/\/files\/.+\/edit$/);
-  await page.locator("[pico-purpose='delete']").click();
+  await page.getByRole("link", { name: "Delete" }).click();
 
   await expect(page).toHaveURL(/\/files\/.+\/confirm-delete$/);
   await page.getByRole("button", { name: "Delete" }).click();

--- a/handlers/templates/pages/file-delete.html
+++ b/handlers/templates/pages/file-delete.html
@@ -54,11 +54,7 @@
 
       <div class="field is-grouped is-flex is-justify-content-flex-end my-5">
         <div class="control">
-          <a
-            class="button is-link is-light"
-            href="/files/{{ .ID }}/edit"
-            pico-purpose="edit"
-          >
+          <a class="button is-link is-light" href="/files/{{ .ID }}/edit">
             Cancel
           </a>
         </div>

--- a/handlers/templates/pages/file-edit.html
+++ b/handlers/templates/pages/file-edit.html
@@ -127,7 +127,7 @@
           </a>
         </div>
         <div class="control">
-          <a href="/files" class="button is-link is-light"> Cancel </a>
+          <a href="/files" class="button is-link is-light">Cancel</a>
         </div>
         <div class="control">
           <button class="button is-primary" id="save-btn">

--- a/handlers/templates/pages/file-edit.html
+++ b/handlers/templates/pages/file-edit.html
@@ -121,20 +121,13 @@
           <a
             class="button is-danger is-justify-item-flex-start"
             href="/files/{{ .ID }}/confirm-delete"
-            pico-purpose="delete"
           >
             <i class="fa fa-trash mr-2"></i>
             Delete
           </a>
         </div>
         <div class="control">
-          <a
-            href="/files"
-            class="button is-link is-light"
-            pico-purpose="cancel"
-          >
-            Cancel
-          </a>
+          <a href="/files" class="button is-link is-light"> Cancel </a>
         </div>
         <div class="control">
           <button class="button is-primary" id="save-btn">

--- a/handlers/templates/pages/file-index.html
+++ b/handlers/templates/pages/file-index.html
@@ -33,7 +33,6 @@
 
 {{ define "script-tags" }}
   <script type="module" nonce="{{ .CspNonce }}">
-    import { deleteFile } from "/js/controllers/files.js";
     import { showElement, hideElement } from "/js/lib/bulma.js";
     import { copyToClipboard } from "/js/lib/clipboard.js";
     import { makeShortLink } from "/js/lib/links.js";

--- a/handlers/templates/pages/file-index.html
+++ b/handlers/templates/pages/file-index.html
@@ -40,30 +40,6 @@
 
     const errorContainer = document.getElementById("error");
 
-    document
-      .querySelectorAll('[pico-purpose="delete"]')
-      .forEach((deleteBtn) => {
-        deleteBtn.addEventListener("click", () => {
-          const id = deleteBtn.getAttribute("pico-entry-id");
-          deleteFile(id)
-            .then(() => {
-              let currentEl = deleteBtn.parentElement;
-              while (currentEl && currentEl.nodeName !== "TR") {
-                currentEl = currentEl.parentElement;
-              }
-              if (!currentEl) {
-                return;
-              }
-
-              currentEl.classList.add("deleted-entry");
-            })
-            .catch((error) => {
-              document.getElementById("error-message").innerText = error;
-              showElement(errorContainer);
-            });
-        });
-      });
-
     document.querySelector("#error .delete").addEventListener("click", () => {
       hideElement(errorContainer);
     });
@@ -132,7 +108,6 @@
                     class="button is-link"
                     href="/files/{{ .ID }}/edit"
                     role="button"
-                    pico-purpose="edit"
                     pico-entry-id="{{ .ID }}"
                   >
                     <i class="fas fa-edit"></i>


### PR DESCRIPTION
Most of them were unused. In other cases, they were only being used in tests, and there are better element selectors.