### PR TITLE
Fix cache headers for static files

### DIFF
--- a/handlers/static.go
+++ b/handlers/static.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"embed"
 	"io/fs"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -20,33 +19,16 @@ func serveStaticResource() http.HandlerFunc {
 		panic(err)
 	}
 	server := http.FileServer(http.FS(fSys))
+	// Because we embed static files in the Go binary, we just use the first time
+	// this function runs as the last modification time for caching headers.
+	lastModificationTime := time.Now()
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Set cache headers
-		if mt, ok := lastModTime(staticFS, r.URL.Path); ok {
-			etag := "\"" + strconv.FormatInt(mt.UnixMilli(), 10) + "\""
-			w.Header().Set("Etag", etag)
-			w.Header().Set("Cache-Control", "max-age=3600")
-		}
+		etag := "\"" + strconv.FormatInt(lastModificationTime.UnixMilli(), 10) + "\""
+		w.Header().Set("Etag", etag)
+		w.Header().Set("Cache-Control", "max-age=3600")
 
 		server.ServeHTTP(w, r)
 	}
-}
-
-func lastModTime(fs fs.FS, path string) (time.Time, bool) {
-	file, err := fs.Open(path)
-	if err != nil {
-		return time.Time{}, false
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			log.Printf("failed to close file handle for %s: %v", path, err)
-		}
-	}()
-
-	stat, err := file.Stat()
-	if err != nil {
-		return time.Time{}, false
-	}
-	return stat.ModTime(), true
 }


### PR DESCRIPTION
We accidentally broke caching for static files in #452 because the technique we were using to look up last modification times of files broke when we started embedding them in the binary.

As a workaround, we now use the last modification time based on the first time the static serving function is called.

Resolves #496