### PR TITLE
Simplify space package

### DIFF
--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/mtlynch/picoshare/v2/garbagecollect"
 	"github.com/mtlynch/picoshare/v2/handlers"
 	"github.com/mtlynch/picoshare/v2/picoshare"
-	"github.com/mtlynch/picoshare/v2/space"
 	"github.com/mtlynch/picoshare/v2/store"
 	"github.com/mtlynch/picoshare/v2/store/test_sqlite"
 )
 
-var nilSpaceChecker space.Checker
+var nilSpaceChecker handlers.SpaceChecker
 var nilGarbageCollector *garbagecollect.Collector
 
 func TestDeleteExistingFile(t *testing.T) {

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -10,11 +10,15 @@ import (
 )
 
 type (
+	SpaceChecker interface {
+		Check() (space.CheckResult, error)
+	}
+
 	Server struct {
 		router        *mux.Router
 		authenticator auth.Authenticator
 		store         store.Store
-		spaceChecker  space.Checker
+		spaceChecker  SpaceChecker
 		collector     *garbagecollect.Collector
 	}
 )
@@ -26,7 +30,7 @@ func (s Server) Router() *mux.Router {
 
 // New creates a new server with all the state it needs to satisfy HTTP
 // requests.
-func New(authenticator auth.Authenticator, store store.Store, spaceChecker space.Checker, collector *garbagecollect.Collector) Server {
+func New(authenticator auth.Authenticator, store store.Store, spaceChecker SpaceChecker, collector *garbagecollect.Collector) Server {
 	s := Server{
 		router:        mux.NewRouter(),
 		authenticator: authenticator,

--- a/space/checker.go
+++ b/space/checker.go
@@ -5,11 +5,7 @@ import (
 )
 
 type (
-	Checker interface {
-		Check() (CheckResult, error)
-	}
-
-	defaultChecker struct {
+	Checker struct {
 		dataDir string
 	}
 
@@ -20,10 +16,10 @@ type (
 )
 
 func NewChecker(dir string) Checker {
-	return defaultChecker{dir}
+	return Checker{dir}
 }
 
-func (c defaultChecker) Check() (CheckResult, error) {
+func (c Checker) Check() (CheckResult, error) {
 	var stat unix.Statfs_t
 	if err := unix.Statfs(c.dataDir, &stat); err != nil {
 		return CheckResult{}, err


### PR DESCRIPTION
It makes more sense for the client to specify the interface they need rather than for the space package to dictate the right interface to clients.