### PR TITLE
Rename environment files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@ data/
 bin/
 dist/
 .coverage*
-*.env
+.env*
 *.test.js
 fly.toml
 modd.conf

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist/
 data/
 
 # Environment variables, which may contain secrets
-*.env
+.env*
 
 # Unit test code coverage output
 .coverage.*

--- a/dev-scripts/download-prod-db
+++ b/dev-scripts/download-prod-db
@@ -15,7 +15,7 @@ export DB_COPY_PATH="data/${TIMESTAMP}.db"
 
 set +x
 # shellcheck disable=SC1091
-. prod.env
+. .env.prod
 set -x
 
 litestream snapshots -config litestream.yml "${DB_PATH}"

--- a/dev-scripts/serve-docker
+++ b/dev-scripts/serve-docker
@@ -19,7 +19,7 @@ DOCKER_BUILDKIT=1 \
 
 set +x
 # shellcheck disable=SC1091
-. dev.env
+. .env.dev
 set -x
 
 PS_SHARED_SECRET=somepassword


### PR DESCRIPTION
Use the .env convention, which is more widely used than whatever.env