### PR TITLE
Export environment variables from download-prod-db

### DIFF
--- a/dev-scripts/download-prod-db
+++ b/dev-scripts/download-prod-db
@@ -18,6 +18,15 @@ set +x
 . .env.prod
 set -x
 
+export LITESTREAM_BUCKET
+export LITESTREAM_ENDPOINT
+export LITESTREAM_ACCESS_KEY_ID
+export LITESTREAM_SECRET_ACCESS_KEY
+
+# Export DB_PATH so that litestream uses the variable to populate
+# litestream.yml.
+export DB_PATH
+
 litestream snapshots -config litestream.yml "${DB_PATH}"
 
 # Retrieve live DB


### PR DESCRIPTION
Don't rely on the .env file to export them.