### PR TITLE
Store the PicoShare version number in the release binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
               readonly BUILD_TARGETS='linux/amd64'
             fi
             docker buildx build \
+              --build-arg "PS_VERSION=$(git describe --tags)" \
               --platform "${BUILD_TARGETS}" \
               --target=artifact \
               --output "type=local,dest=$(pwd)/bin/" \


### PR DESCRIPTION
Resolves #558 

I forgot to include the `PS_VERSION` Docker build arg when building the release binaries, which caused the version displayed in the web app to be empty. Adding the proper arg should fix the issue.