### PR TITLE
fix http server graceful shutdown

### DIFF
--- a/cmd/picoshare/main.go
+++ b/cmd/picoshare/main.go
@@ -61,7 +61,7 @@ func main() {
 	httpSrv := http.Server{Addr: fmt.Sprintf(":%s", port), Handler: h}
 	go func() {
 		log.Printf("listening on %s", port)
-		log.Fatal(httpSrv.ListenAndServe())
+		log.Printf("http server exit: %s", httpSrv.ListenAndServe())
 	}()
 	<-stop
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
as golang's http doc point out

```
ListenAndServe always returns a non-nil error. After Shutdown or Close
```

`log.Fatal(httpSrv.ListenAndServe())` will cause server exit immediately with code 1, without waiting 5s for graceful shutdown.