### PR TITLE
Assert against result object instead of recorder

### DIFF
--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -31,10 +31,11 @@ func TestDeleteExistingFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := httptest.NewRecorder()
-	s.Router().ServeHTTP(w, req)
+	rec := httptest.NewRecorder()
+	s.Router().ServeHTTP(rec, req)
+	res := rec.Result()
 
-	if status := w.Code; status != http.StatusOK {
+	if status := res.StatusCode; status != http.StatusOK {
 		t.Fatalf("DELETE /api/entry returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
@@ -54,11 +55,12 @@ func TestDeleteNonExistentFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := httptest.NewRecorder()
-	s.Router().ServeHTTP(w, req)
+	rec := httptest.NewRecorder()
+	s.Router().ServeHTTP(rec, req)
+	res := rec.Result()
 
 	// File doesn't exist, but there's no error for deleting a non-existent file.
-	if status := w.Code; status != http.StatusOK {
+	if status := res.StatusCode; status != http.StatusOK {
 		t.Fatalf("DELETE /api/entry returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
@@ -73,11 +75,12 @@ func TestDeleteInvalidEntryID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := httptest.NewRecorder()
-	s.Router().ServeHTTP(w, req)
+	rec := httptest.NewRecorder()
+	s.Router().ServeHTTP(rec, req)
+	res := rec.Result()
 
 	// File doesn't exist, but there's no error for deleting a non-existent file.
-	if status := w.Code; status != http.StatusBadRequest {
+	if status := res.StatusCode; status != http.StatusBadRequest {
 		t.Fatalf("DELETE /api/entry returned wrong status code: got %v want %v",
 			status, http.StatusBadRequest)
 	}

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -123,10 +123,11 @@ func TestEntryGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			w := httptest.NewRecorder()
-			s.Router().ServeHTTP(w, req)
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
 
-			if got, want := w.Code, tt.expectedStatus; got != want {
+			if got, want := res.StatusCode, tt.expectedStatus; got != want {
 				t.Fatalf("%s returned wrong status code: got %v want %v",
 					tt.requestRoute, got, want)
 			}
@@ -135,11 +136,11 @@ func TestEntryGet(t *testing.T) {
 				return
 			}
 
-			if got, want := w.Header().Get("Content-Disposition"), tt.expectedContentDisposition; got != want {
+			if got, want := res.Header.Get("Content-Disposition"), tt.expectedContentDisposition; got != want {
 				t.Errorf("Content-Disposition=%s, want=%s", got, want)
 			}
 
-			if got, want := w.Header().Get("Content-Type"), tt.expectedContentType; got != want {
+			if got, want := res.Header.Get("Content-Type"), tt.expectedContentType; got != want {
 				t.Errorf("Content-Type=%s, want=%s", got, want)
 			}
 		})

--- a/handlers/settings_test.go
+++ b/handlers/settings_test.go
@@ -74,10 +74,11 @@ func TestSettingsPut(t *testing.T) {
 			}
 			req.Header.Add("Content-Type", "text/json")
 
-			w := httptest.NewRecorder()
-			s.Router().ServeHTTP(w, req)
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
 
-			if got, want := w.Code, tt.status; got != want {
+			if got, want := res.StatusCode, tt.status; got != want {
 				t.Fatalf("/api/settings returned wrong status code: got %v want %v",
 					got, want)
 			}

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -103,22 +103,28 @@ func TestEntryPost(t *testing.T) {
 			}
 			req.Header.Add("Content-Type", contentType)
 
-			w := httptest.NewRecorder()
-			s.Router().ServeHTTP(w, req)
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
 
-			if got, want := w.Code, tt.status; got != want {
+			if got, want := res.StatusCode, tt.status; got != want {
 				t.Errorf("status=%d, want=%d", got, want)
 			}
 
 			// Only check the response if the request succeeded.
-			if w.Code != http.StatusOK {
+			if res.StatusCode != http.StatusOK {
 				return
 			}
 
-			var response handlers.EntryPostResponse
-			err = json.Unmarshal(w.Body.Bytes(), &response)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
-				t.Fatalf("response is not valid JSON: %v", w.Body.String())
+				t.Fatalf("failed to read response body")
+			}
+
+			var response handlers.EntryPostResponse
+			err = json.Unmarshal(body, &response)
+			if err != nil {
+				t.Fatalf("response is not valid JSON: %v", body)
 			}
 
 			entry, err := dataStore.GetEntry(picoshare.EntryID(response.ID))
@@ -233,10 +239,11 @@ func TestEntryPut(t *testing.T) {
 			}
 			req.Header.Add("Content-Type", "text/json")
 
-			w := httptest.NewRecorder()
-			s.Router().ServeHTTP(w, req)
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
 
-			if got, want := w.Code, tt.status; got != want {
+			if got, want := res.StatusCode, tt.status; got != want {
 				t.Fatalf("status=%d, want=%d", got, want)
 			}
 
@@ -396,22 +403,28 @@ func TestGuestUpload(t *testing.T) {
 			req.Header.Add("Content-Type", contentType)
 			req.Header.Add("Accept", "application/json")
 
-			w := httptest.NewRecorder()
-			s.Router().ServeHTTP(w, req)
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
 
-			if got, want := w.Code, tt.status; got != want {
+			if got, want := res.StatusCode, tt.status; got != want {
 				t.Fatalf("status=%d, want=%d", got, want)
 			}
 
 			// Only check the response if the request succeeded.
-			if w.Code != http.StatusOK {
+			if res.StatusCode != http.StatusOK {
 				return
 			}
 
-			var response handlers.EntryPostResponse
-			err = json.Unmarshal(w.Body.Bytes(), &response)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
-				t.Fatalf("response is not valid JSON: %v", w.Body.String())
+				t.Fatalf("failed to read response body")
+			}
+
+			var response handlers.EntryPostResponse
+			err = json.Unmarshal(body, &response)
+			if err != nil {
+				t.Fatalf("response is not valid JSON: %v", body)
 			}
 
 			entry, err := store.GetEntry(picoshare.EntryID(response.ID))


### PR DESCRIPTION
I noticed that there is a subtle issue in the test setup, which could potentially lead to false positive test results.

According to the [documentation of `httptest.ResponseRecorder` (see their example)](https://pkg.go.dev/net/http/httptest#ResponseRecorder), you are supposed to run the test assertions against the result object returned by `recorder.Result()`, rather than against the recorder object itself.

The recorder object basically tracks all interactions of the request handlers with the response. However, this may be different from what the HTTP server actually sends out to the client.

One such edge-case scenario is when you try to set response headers after having flushed out the response headers. In this case, any attempt to modify the headers via `res.Headers().Set()` will silently result in a no-op. The response object issued by `rec.Result()` correctly reflects that, whereas the recorder object itself incorrectly yields the seemingly set header.

- [Before the fix](https://github.com/jotaen/picoshare/compare/master...jotaen:picoshare:fix-test-setup-demo-before?expand=1): the tests all pass, but in reality, no `Content-Type` header was set
- [After the fix](https://github.com/jotaen/picoshare/compare/fix-test-setup...jotaen:picoshare:fix-test-setup-demo-after?expand=1): the tests fail
