### PR TITLE
Get rid of FileLifetime.Duration function

### DIFF
--- a/handlers/views.go
+++ b/handlers/views.go
@@ -124,7 +124,7 @@ func (s Server) guestLinksNewGet() http.HandlerFunc {
 			return t.Format(time.RFC3339)
 		},
 		"formatLifetime": func(flt picoshare.FileLifetime) string {
-			return flt.Duration().String()
+			return flt.String()
 		},
 	}
 
@@ -484,7 +484,7 @@ func (s Server) uploadGet() http.HandlerFunc {
 		if !defaultIsBuiltIn {
 			lifetimeOptions = append(lifetimeOptions, lifetimeOption{settings.DefaultFileLifetime, true})
 			sort.Slice(lifetimeOptions, func(i, j int) bool {
-				return lifetimeOptions[i].Lifetime.Duration() < lifetimeOptions[j].Lifetime.Duration()
+				return lifetimeOptions[i].Lifetime.LessThan(lifetimeOptions[j].Lifetime)
 			})
 		}
 
@@ -496,13 +496,13 @@ func (s Server) uploadGet() http.HandlerFunc {
 		expirationOptions := []expirationOption{}
 		for _, lto := range lifetimeOptions {
 			friendlyName := lto.Lifetime.FriendlyName()
-			expiration := time.Now().Add(lto.Lifetime.Duration())
+			expiration := lto.Lifetime.ExpirationFromTime(time.Now())
 			if lto.Lifetime.Equal(picoshare.FileLifetimeInfinite) {
-				expiration = time.Time(picoshare.NeverExpire)
+				expiration = picoshare.NeverExpire
 			}
 			expirationOptions = append(expirationOptions, expirationOption{
 				FriendlyName: friendlyName,
-				Expiration:   expiration,
+				Expiration:   expiration.Time(),
 				IsDefault:    lto.IsDefault,
 			})
 		}

--- a/picoshare/file_lifetime.go
+++ b/picoshare/file_lifetime.go
@@ -39,10 +39,6 @@ func NewFileLifetimeInYears(years uint16) FileLifetime {
 	return NewFileLifetimeInDays(years * daysPerYear)
 }
 
-func (lt FileLifetime) Duration() time.Duration {
-	return lt.d
-}
-
 func (lt FileLifetime) Days() uint16 {
 	hoursPerDay := uint16(24)
 	return uint16(lt.d.Hours() / float64(hoursPerDay))
@@ -54,6 +50,10 @@ func (lt FileLifetime) Years() uint16 {
 
 func (lt FileLifetime) IsYearBoundary() bool {
 	return lt.Days()%daysPerYear == 0
+}
+
+func (lt FileLifetime) String() string {
+	return lt.d.String()
 }
 
 func (lt FileLifetime) FriendlyName() string {
@@ -70,6 +70,10 @@ func (lt FileLifetime) FriendlyName() string {
 		unit += "s"
 	}
 	return fmt.Sprintf("%d %s", value, unit)
+}
+
+func (lt FileLifetime) LessThan(o FileLifetime) bool {
+	return lt.d == o.d
 }
 
 func (lt FileLifetime) Equal(o FileLifetime) bool {

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -51,7 +51,11 @@ func (f Filename) String() string {
 }
 
 func (et ExpirationTime) String() string {
-	return (time.Time(et)).String()
+	return et.Time().String()
+}
+
+func (et ExpirationTime) Time() time.Time {
+	return time.Time(et)
 }
 
 func (n FileNote) String() string {

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -75,7 +75,7 @@ func formatTime(t time.Time) string {
 }
 
 func formatFileLifetime(lt picoshare.FileLifetime) string {
-	return lt.Duration().String()
+	return lt.String()
 }
 
 func parseDatetime(s string) (time.Time, error) {


### PR DESCRIPTION
It breaks encapsulation too much to just hand callers the underlying object.