### PR TITLE
Add a clock interface to the server

### DIFF
--- a/cmd/picoshare/main.go
+++ b/cmd/picoshare/main.go
@@ -45,7 +45,9 @@ func main() {
 	gc := garbagecollect.NewScheduler(&collector, 7*time.Hour)
 	gc.StartAsync()
 
-	server := handlers.New(authenticator, &store, spaceChecker, &collector)
+	clock := handlers.NewClock()
+
+	server := handlers.New(authenticator, &store, spaceChecker, &collector, &clock)
 
 	h := gorilla.LoggingHandler(os.Stdout, server.Router())
 	if os.Getenv("PS_BEHIND_PROXY") != "" {

--- a/handlers/clock.go
+++ b/handlers/clock.go
@@ -1,0 +1,13 @@
+package handlers
+
+import "time"
+
+type defaultClock struct{}
+
+func (c defaultClock) Now() time.Time {
+	return time.Now()
+}
+
+func NewClock() defaultClock {
+	return defaultClock{}
+}

--- a/handlers/delete_test.go
+++ b/handlers/delete_test.go
@@ -24,7 +24,7 @@ func TestDeleteExistingFile(t *testing.T) {
 			ID:   picoshare.EntryID("hR87apiUCj"),
 			Size: uint64(len(fileContents)),
 		})
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/entry/hR87apiUCj", nil)
 	if err != nil {
@@ -48,7 +48,7 @@ func TestDeleteExistingFile(t *testing.T) {
 
 func TestDeleteNonExistentFile(t *testing.T) {
 	dataStore := test_sqlite.New()
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/entry/hR87apiUCj", nil)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestDeleteNonExistentFile(t *testing.T) {
 
 func TestDeleteInvalidEntryID(t *testing.T) {
 	dataStore := test_sqlite.New()
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/entry/invalid-entry-id", nil)
 	if err != nil {

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -116,7 +116,7 @@ func TestEntryGet(t *testing.T) {
 				}
 			}
 
-			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			req, err := http.NewRequest("GET", tt.requestRoute, nil)
 			if err != nil {

--- a/handlers/guest_links.go
+++ b/handlers/guest_links.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mtlynch/picoshare/v2/handlers/parse"
@@ -35,7 +34,7 @@ func (s Server) guestLinksPost() http.HandlerFunc {
 		}
 
 		gl.ID = generateGuestLinkID()
-		gl.Created = time.Now()
+		gl.Created = s.clock.Now()
 
 		if err := s.getDB(r).InsertGuestLink(gl); err != nil {
 			log.Printf("failed to save guest link: %v", err)

--- a/handlers/guest_links_test.go
+++ b/handlers/guest_links_test.go
@@ -94,7 +94,7 @@ func TestGuestLinksPostAcceptsValidRequest(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			req, err := http.NewRequest("POST", "/api/guest-links", strings.NewReader(tt.payload))
 			if err != nil {
@@ -252,7 +252,7 @@ func TestGuestLinksPostRejectsInvalidRequest(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			req, err := http.NewRequest("POST", "/api/guest-links", strings.NewReader(tt.payload))
 			if err != nil {
@@ -288,7 +288,7 @@ func TestDeleteExistingGuestLink(t *testing.T) {
 		UrlExpires: mustParseExpirationTime("2030-01-02T03:04:25Z"),
 	})
 
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/abcdefgh23456789", nil)
 	if err != nil {
@@ -311,7 +311,7 @@ func TestDeleteExistingGuestLink(t *testing.T) {
 
 func TestDeleteNonExistentGuestLink(t *testing.T) {
 	dataStore := test_sqlite.New()
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/abcdefgh23456789", nil)
 	if err != nil {
@@ -331,7 +331,7 @@ func TestDeleteNonExistentGuestLink(t *testing.T) {
 
 func TestDeleteInvalidGuestLink(t *testing.T) {
 	dataStore := test_sqlite.New()
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 	req, err := http.NewRequest("DELETE", "/api/guest-links/i-am-an-invalid-link", nil)
 	if err != nil {

--- a/handlers/server.go
+++ b/handlers/server.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/gorilla/mux"
 
 	"github.com/mtlynch/picoshare/v2/garbagecollect"
@@ -13,12 +15,17 @@ type (
 		Check() (space.Usage, error)
 	}
 
+	Clock interface {
+		Now() time.Time
+	}
+
 	Server struct {
 		router        *mux.Router
 		authenticator auth.Authenticator
 		store         Store
 		spaceChecker  SpaceChecker
 		collector     *garbagecollect.Collector
+		clock         Clock
 	}
 )
 
@@ -29,13 +36,14 @@ func (s Server) Router() *mux.Router {
 
 // New creates a new server with all the state it needs to satisfy HTTP
 // requests.
-func New(authenticator auth.Authenticator, store Store, spaceChecker SpaceChecker, collector *garbagecollect.Collector) Server {
+func New(authenticator auth.Authenticator, store Store, spaceChecker SpaceChecker, collector *garbagecollect.Collector, clock Clock) Server {
 	s := Server{
 		router:        mux.NewRouter(),
 		authenticator: authenticator,
 		store:         store,
 		spaceChecker:  spaceChecker,
 		collector:     collector,
+		clock:         clock,
 	}
 
 	s.routes()

--- a/handlers/settings_test.go
+++ b/handlers/settings_test.go
@@ -66,7 +66,7 @@ func TestSettingsPut(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			req, err := http.NewRequest("PUT", "/api/settings", strings.NewReader(tt.payload))
 			if err != nil {

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mtlynch/picoshare/v2/handlers/parse"
@@ -132,7 +131,7 @@ func (s Server) guestEntryPost() http.HandlerFunc {
 			r.Body = http.MaxBytesReader(w, r.Body, int64(*gl.MaxFileBytes))
 		}
 
-		id, err := s.insertFileFromRequest(r, gl.FileLifetime.ExpirationFromTime(time.Now()), guestLinkID)
+		id, err := s.insertFileFromRequest(r, gl.FileLifetime.ExpirationFromTime(s.clock.Now()), guestLinkID)
 		if err != nil {
 			var de *dbError
 			if errors.As(err, &de) {
@@ -268,7 +267,7 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 			GuestLink: picoshare.GuestLink{
 				ID: guestLinkID,
 			},
-			Uploaded: time.Now(),
+			Uploaded: s.clock.Now(),
 			Expires:  expiration,
 		})
 	if err != nil {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -94,7 +94,7 @@ func TestEntryPost(t *testing.T) {
 	} {
 		t.Run(tt.description, func(t *testing.T) {
 			dataStore := test_sqlite.New()
-			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			formData, contentType := createMultipartFormBody(tt.filename, tt.note, bytes.NewBuffer([]byte(tt.contents)))
 
@@ -232,7 +232,7 @@ func TestEntryPut(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			store := test_sqlite.New()
 			store.InsertEntry(strings.NewReader(("dummy data")), originalEntry)
-			s := handlers.New(mockAuthenticator{}, &store, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(mockAuthenticator{}, &store, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			req, err := http.NewRequest("PUT", "/api/entry/"+tt.targetID, strings.NewReader(tt.payload))
 			if err != nil {
@@ -418,7 +418,7 @@ func TestGuestUpload(t *testing.T) {
 				}
 			}
 
-			s := handlers.New(authenticator, &store, nilSpaceChecker, nilGarbageCollector)
+			s := handlers.New(authenticator, &store, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
 			filename := "dummyimage.png"
 			contents := "dummy bytes"

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -147,10 +147,10 @@ func (s Server) guestLinksNewGet() http.HandlerFunc {
 		}{
 			commonProps: makeCommonProps("PicoShare - New Guest Link", r.Context()),
 			ExpirationOptions: []expirationOption{
-				{"1 day", time.Now().AddDate(0, 0, 1), false},
-				{"7 days", time.Now().AddDate(0, 0, 7), false},
-				{"30 days", time.Now().AddDate(0, 0, 30), false},
-				{"1 year", time.Now().AddDate(1, 0, 0), false},
+				{"1 day", s.clock.Now().AddDate(0, 0, 1), false},
+				{"7 days", s.clock.Now().AddDate(0, 0, 7), false},
+				{"30 days", s.clock.Now().AddDate(0, 0, 30), false},
+				{"1 year", s.clock.Now().AddDate(1, 0, 0), false},
 				{"Never", time.Time(picoshare.NeverExpire), true},
 			},
 			FileLifetimeOptions: []fileLifetimeOption{
@@ -496,7 +496,7 @@ func (s Server) uploadGet() http.HandlerFunc {
 		expirationOptions := []expirationOption{}
 		for _, lto := range lifetimeOptions {
 			friendlyName := lto.Lifetime.FriendlyName()
-			expiration := lto.Lifetime.ExpirationFromTime(time.Now())
+			expiration := lto.Lifetime.ExpirationFromTime(s.clock.Now())
 			if lto.Lifetime.Equal(picoshare.FileLifetimeInfinite) {
 				expiration = picoshare.NeverExpire
 			}


### PR DESCRIPTION
Checking the time through a clock interface rather than through time.Now allows us to mock out the time in tests where the time makes a difference such as #619