### PR TITLE
Make chunk size a uint64

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -236,7 +236,10 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 
 	if metadata.Size == 0 {
 		return picoshare.EntryID(""), errors.New("file is empty")
+	} else if metadata.Size < 0 {
+		return picoshare.EntryID(""), errors.New("file size must be positive")
 	}
+	fileSize := uint64(metadata.Size)
 
 	filename, err := parse.Filename(metadata.Filename)
 	if err != nil {
@@ -269,6 +272,7 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 			},
 			Uploaded: s.clock.Now(),
 			Expires:  expiration,
+			Size:     fileSize,
 		})
 	if err != nil {
 		log.Printf("failed to save entry: %v", err)

--- a/store/sqlite/entries_test.go
+++ b/store/sqlite/entries_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestInsertDeleteSingleEntry(t *testing.T) {
-	chunkSize := 5
+	chunkSize := uint64(5)
 	db := test_sqlite.NewWithChunkSize(chunkSize)
 
 	if err := db.InsertEntry(bytes.NewBufferString("hello, world!"), picoshare.UploadMetadata{
@@ -76,7 +76,7 @@ func TestInsertDeleteSingleEntry(t *testing.T) {
 }
 
 func TestReadLastByteOfEntry(t *testing.T) {
-	chunkSize := 5
+	chunkSize := uint64(5)
 	db := test_sqlite.NewWithChunkSize(chunkSize)
 
 	if err := db.InsertEntry(bytes.NewBufferString("hello, world!"), picoshare.UploadMetadata{

--- a/store/sqlite/file/writer.go
+++ b/store/sqlite/file/writer.go
@@ -16,7 +16,7 @@ type writer struct {
 
 // Create a new writer for the entry ID using the given SqlTx and splitting the
 // file into separate rows in the DB of at most chunkSize bytes.
-func NewWriter(ctx wrapped.SqlDB, id picoshare.EntryID, chunkSize int) io.WriteCloser {
+func NewWriter(ctx wrapped.SqlDB, id picoshare.EntryID, chunkSize uint64) io.WriteCloser {
 	return &writer{
 		ctx:     ctx,
 		entryID: id,

--- a/store/sqlite/file/writer_test.go
+++ b/store/sqlite/file/writer_test.go
@@ -42,7 +42,7 @@ func TestWriteFile(t *testing.T) {
 		explanation  string
 		id           picoshare.EntryID
 		data         []byte
-		chunkSize    int
+		chunkSize    uint64
 		sqlExecErr   error
 		errExpected  error
 		rowsExpected []mockChunkRow

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -13,13 +13,13 @@ import (
 const (
 	timeFormat = time.RFC3339
 	// I think Chrome reads in 32768 chunks, but I haven't checked rigorously.
-	defaultChunkSize = 32768 * 10
+	defaultChunkSize = uint64(32768 * 10)
 )
 
 type (
 	Store struct {
 		ctx       *sql.DB
-		chunkSize int
+		chunkSize uint64
 	}
 
 	rowScanner interface {
@@ -33,7 +33,7 @@ func New(path string, optimizeForLitestream bool) Store {
 
 // NewWithChunkSize creates a SQLite-based datastore with the user-specified
 // chunk size for writing files. Most callers should just use New().
-func NewWithChunkSize(path string, chunkSize int, optimizeForLitestream bool) Store {
+func NewWithChunkSize(path string, chunkSize uint64, optimizeForLitestream bool) Store {
 	log.Printf("reading DB from %s", path)
 	ctx, err := sql.Open("sqlite3", path)
 	if err != nil {

--- a/store/test_sqlite/db.go
+++ b/store/test_sqlite/db.go
@@ -13,7 +13,7 @@ func New() sqlite.Store {
 	return sqlite.New(ephemeralDbURI(), optimizeForLitestream)
 }
 
-func NewWithChunkSize(chunkSize int) sqlite.Store {
+func NewWithChunkSize(chunkSize uint64) sqlite.Store {
 	return sqlite.NewWithChunkSize(ephemeralDbURI(), chunkSize, optimizeForLitestream)
 }
 


### PR DESCRIPTION
It can't be negative anyway, so uint is better than int, and uint64 makes it work nicely with other values around file size that have to be uint64.