### PR TITLE
Delete references to guest link before deleting the link

### DIFF
--- a/store/sqlite/guest_links.go
+++ b/store/sqlite/guest_links.go
@@ -105,15 +105,6 @@ func (s Store) DeleteGuestLink(id picoshare.GuestLinkID) error {
 	}
 
 	if _, err = tx.Exec(`
-	DELETE FROM
-		guest_links
-	WHERE
-		id=:id`, sql.Named("id", id)); err != nil {
-		log.Printf("deleting %s from guest_links table failed: %v", id, err)
-		return err
-	}
-
-	if _, err = tx.Exec(`
 	UPDATE
 		entries
 	SET
@@ -121,6 +112,15 @@ func (s Store) DeleteGuestLink(id picoshare.GuestLinkID) error {
 	WHERE
 		guest_link_id = :id`, sql.Named("id", id)); err != nil {
 		log.Printf("removing references to guest link %s from entries table failed: %v", id, err)
+		return err
+	}
+
+	if _, err = tx.Exec(`
+	DELETE FROM
+		guest_links
+	WHERE
+		id=:id`, sql.Named("id", id)); err != nil {
+		log.Printf("deleting %s from guest_links table failed: %v", id, err)
 		return err
 	}
 


### PR DESCRIPTION
For some reason, the mattn driver doesn't catch this violation of the FOREIGN KEY constraint, but ncruces does. The fix is to just switch up the order so that we delete the references before deleting the underlying data. It's in a transaction, so we shouldn't be able to end up with invalid data.