### PR TITLE
Delete references to entries before deleting entries

### DIFF
--- a/store/sqlite/entries.go
+++ b/store/sqlite/entries.go
@@ -258,19 +258,19 @@ func (s Store) DeleteEntry(id picoshare.EntryID) error {
 
 	if _, err := tx.Exec(`
 	DELETE FROM
-		entries
+		entries_data
 	WHERE
 		id = :entry_id`, sql.Named("entry_id", id)); err != nil {
-		log.Printf("delete from entries table failed, aborting transaction: %v", err)
+		log.Printf("delete from entries_data table failed, aborting transaction: %v", err)
 		return err
 	}
 
 	if _, err := tx.Exec(`
 	DELETE FROM
-		entries_data
+		entries
 	WHERE
 		id = :entry_id`, sql.Named("entry_id", id)); err != nil {
-		log.Printf("delete from entries_data table failed, aborting transaction: %v", err)
+		log.Printf("delete from entries table failed, aborting transaction: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
This is to avoid violating FOREIGN KEY constraints, similar to 856240aa858be137ebc6effe828ab81881c8d71f