### PR TITLE
Fix formatter in expiration picker

### DIFF
--- a/handlers/templates/custom-elements/expiration-picker.html
+++ b/handlers/templates/custom-elements/expiration-picker.html
@@ -33,8 +33,12 @@
       );
     }
 
+    // Format the date in YYYY-MM-DD format without converting to UTC time.
     function formatDate(date) {
-      return date.toISOString().split("T")[0];
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      return `${year}-${month}-${day}`;
     }
 
     function tomorrow() {


### PR DESCRIPTION
I don't think this will fix #641, but it gets rid of an unintentional time zone conversion and makes the code clearer.