### PR TITLE
Show expiration time in server's local time

### DIFF
--- a/handlers/views.go
+++ b/handlers/views.go
@@ -262,9 +262,10 @@ func (s Server) fileInfoGet() http.HandlerFunc {
 			if et == picoshare.NeverExpire {
 				return "Never"
 			}
-			t := time.Time(et)
+			t := et.Time().Local()
 			delta := t.Sub(s.clock.Now())
-			return fmt.Sprintf("%s (%.0f days)", t.Format(time.DateOnly), delta.Hours()/24)
+			daysRemaining := delta.Hours() / 24
+			return fmt.Sprintf("%s (%.0f days)", t.Format(time.DateOnly), daysRemaining)
 		},
 		"formatTimestamp": func(t time.Time) string {
 			return t.Format(time.RFC3339)


### PR DESCRIPTION
The server is currently showing the expiration time in UTC time zone. For users in time zones behind UTC, this causes the expiration date to display a day behind.

The server's local time is probably going to be closer to the client's time zone, so this change uses the server's time zone to display expiration time on the file info page.

Resolves: #641 