### PR TITLE
Delete isActive template function

### DIFF
--- a/handlers/templates/pages/guest-link-index.html
+++ b/handlers/templates/pages/guest-link-index.html
@@ -129,9 +129,9 @@
       </thead>
       <tbody>
         {{ range .GuestLinks }}
-          <tr {{ if not (isActive .) }}class="inactive"{{ end }}>
+          <tr {{ if not .IsActive }}class="inactive"{{ end }}>
             <td class="is-vcentered">
-              {{ if isActive . }}
+              {{ if .IsActive }}
                 <a href="/g/{{ .ID }}">
                   {{ template "label-formatted" . }}
                 </a>

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -87,9 +87,6 @@ func (s Server) guestLinkIndexGet() http.HandlerFunc {
 			}
 			return fmt.Sprintf("%s (%.0f days%s)", t.Format(time.DateOnly), math.Abs(delta.Hours())/24, suffix)
 		},
-		"isActive": func(gl picoshare.GuestLink) bool {
-			return gl.IsActive()
-		},
 	}
 
 	t := parseTemplatesWithFuncs(fns, "templates/pages/guest-link-index.html")


### PR DESCRIPTION
It wasn't actually necessary as templates can call the regular function directly.