### PR TITLE
Define upload time in garbagecollect tests

### DIFF
--- a/garbagecollect/collect_test.go
+++ b/garbagecollect/collect_test.go
@@ -39,33 +39,38 @@ func TestCollectExpiredFile(t *testing.T) {
 	expireInFiveMins := makeRelativeExpirationTime(5 * time.Minute)
 	dataStore.InsertEntry(strings.NewReader(d),
 		picoshare.UploadMetadata{
-			ID:      picoshare.EntryID("AAAAAAAAAAAA"),
-			Expires: mustParseExpirationTime("2024-01-01T00:00:00Z"),
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("AAAAAAAAAAAA"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  mustParseExpirationTime("2024-01-01T00:00:00Z"),
+			Size:     mustParseFileSize(len(d)),
 		})
 	dataStore.InsertEntry(strings.NewReader(d),
 		picoshare.UploadMetadata{
-			ID:      picoshare.EntryID("BBBBBBBBBBBB"),
-			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("BBBBBBBBBBBB"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  mustParseExpirationTime("3000-01-01T00:00:00Z"),
+			Size:     mustParseFileSize(len(d)),
 		})
 	dataStore.InsertEntry(strings.NewReader(d),
 		picoshare.UploadMetadata{
-			ID:      picoshare.EntryID("CCCCCCCCCCCC"),
-			Expires: picoshare.NeverExpire,
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("CCCCCCCCCCCC"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  picoshare.NeverExpire,
+			Size:     mustParseFileSize(len(d)),
 		})
 	dataStore.InsertEntry(strings.NewReader(d),
 		picoshare.UploadMetadata{
-			ID:      picoshare.EntryID("DDDDDDDDDDDD"),
-			Expires: makeRelativeExpirationTime(-1 * time.Second),
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("DDDDDDDDDDDD"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  makeRelativeExpirationTime(-1 * time.Second),
+			Size:     mustParseFileSize(len(d)),
 		})
 	dataStore.InsertEntry(strings.NewReader(d),
 		picoshare.UploadMetadata{
-			ID:      picoshare.EntryID("EEEEEEEEEEEE"),
-			Expires: expireInFiveMins,
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("EEEEEEEEEEEE"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  expireInFiveMins,
+			Size:     mustParseFileSize(len(d)),
 		})
 
 	c := garbagecollect.NewCollector(dataStore)
@@ -81,19 +86,22 @@ func TestCollectExpiredFile(t *testing.T) {
 
 	expected := []picoshare.UploadMetadata{
 		{
-			ID:      picoshare.EntryID("BBBBBBBBBBBB"),
-			Expires: mustParseExpirationTime("3000-01-01T00:00:00Z"),
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("BBBBBBBBBBBB"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  mustParseExpirationTime("3000-01-01T00:00:00Z"),
+			Size:     mustParseFileSize(len(d)),
 		},
 		{
-			ID:      picoshare.EntryID("CCCCCCCCCCCC"),
-			Expires: picoshare.NeverExpire,
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("CCCCCCCCCCCC"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  picoshare.NeverExpire,
+			Size:     mustParseFileSize(len(d)),
 		},
 		{
-			ID:      picoshare.EntryID("EEEEEEEEEEEE"),
-			Expires: expireInFiveMins,
-			Size:    mustParseFileSize(len(d)),
+			ID:       picoshare.EntryID("EEEEEEEEEEEE"),
+			Uploaded: mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:  expireInFiveMins,
+			Size:     mustParseFileSize(len(d)),
 		},
 	}
 	if diff := deep.Equal(expected, remaining); diff != nil {
@@ -168,6 +176,14 @@ func TestCollectDoesNothingWhenNoFilesAreExpired(t *testing.T) {
 		t.Errorf("diff=%+v", diff)
 		t.FailNow()
 	}
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 func mustParseExpirationTime(s string) picoshare.ExpirationTime {


### PR DESCRIPTION
We're adding stricter validation to the DB soon, so this avoids breaking tests.