### PR TITLE
Allow use of PS_SHARED_SECRET_FILE var for Docker Secrets

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -6,6 +6,32 @@ set -e
 # Exit on unset variable.
 set -u
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+       local var="$1"
+       local fileVar="${var}_FILE"
+       local def="${2:-}"
+       local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+       local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+       if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+               echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+               exit 1
+       fi
+       if [ -n "${varValue}" ]; then
+               export "$var"="${varValue}"
+       elif [ -n "${fileVarValue}" ]; then
+               export "$var"="$(cat "${fileVarValue}")"
+       elif [ -n "${def}" ]; then
+               export "$var"="$def"
+       fi
+       unset "$fileVar"
+}
+
+file_env PS_SHARED_SECRET
+
 PS_ARGS="$*"
 readonly PS_ARGS
 

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -14,8 +14,10 @@ file_env() {
        local var="$1"
        local fileVar="${var}_FILE"
        local def="${2:-}"
-       local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
-       local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+       local varValue
+       varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+       local fileVarValue
+       fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
        if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
                echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
                exit 1


### PR DESCRIPTION
This PR adds the `file_env` function within `docker-entrypoint`, which as far as I can tell is the standard way to implement _FILE vars for Docker Secrets support.

Please let me know if you have any questions or concerns!