### PR TITLE
Fix foreign key reference in database migrations

### DIFF
--- a/store/sqlite/migrations/011-downloads-id-as-text.sql
+++ b/store/sqlite/migrations/011-downloads-id-as-text.sql
@@ -15,7 +15,8 @@ SELECT
     download_timestamp,
     client_ip,
     user_agent
-FROM downloads;
+FROM downloads
+WHERE entry_id IN (SELECT id FROM entries);
 
 DROP TABLE downloads;
 

--- a/store/sqlite/migrations/012-fix-entries_data-foreign-key.sql
+++ b/store/sqlite/migrations/012-fix-entries_data-foreign-key.sql
@@ -14,7 +14,8 @@ SELECT
     id,
     chunk_index,
     chunk
-FROM entries_data;
+FROM entries_data
+WHERE id IN (SELECT id FROM entries);
 
 DROP TABLE entries_data;
 


### PR DESCRIPTION
The existing migration failed to account for orphaned rows in the download table and entries_data table that referred to files that had been deleted.

This fixes the migration so that we only migrate over rows that are not orphaned.

Fixes #705