### PR TITLE
Add support for protecting files with a passphrase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY ./cmd /app/cmd
 COPY ./dev-scripts /app/dev-scripts
 COPY ./garbagecollect /app/garbagecollect
 COPY ./handlers /app/handlers
+COPY ./kdf /app/kdf
 COPY ./picoshare /app/picoshare
 COPY ./random /app/random
 COPY ./space /app/space

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ PicoShare is easy to deploy to cloud hosting platforms:
 
 ## Tips and tricks
 
+### Passphrase protection (optional)
+
+You can optionally protect any upload with a passphrase:
+
+- At upload time, enter a passphrase in the new "Passphrase" field. PicoShare derives a key via a KDF and stores only that derived value alongside the file metadata. The file contents remain unencrypted (cleartext) on the server.
+- When someone opens the share link, PicoShare will prompt for the passphrase. Access is granted if the entered passphrase derives to the same key.
+- From the admin file edit screen, you can set a new passphrase or clear it. Leaving the passphrase field empty when saving clears the passphrase protection; omitting the field leaves it unchanged.
+
+Notes:
+
+- The passphrase is never stored in plaintext; only the derived key is stored.
+- For security, passphrases are submitted via form POST (not URL/query params).
+
 ### Reclaiming reserved database space
 
 Some users find it surprising that when they delete files from PicoShare, they don't gain back free space on their filesystem.

--- a/e2e/passphrase.spec.ts
+++ b/e2e/passphrase.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+import { login } from "./helpers/login";
+
+// Reuse columns mapping from upload.spec where needed
+const noteColumn = 1;
+
+test("uploads a file with a passphrase and requires it on download", async ({ page, request }) => {
+  await login(page);
+
+  // Set a note just to ensure it doesn't leak into the prompt page.
+  await page.locator("#note").fill("private note - should not appear on prompt");
+  await page.locator("#passphrase").fill("letmein");
+
+  await page.locator(".file-input").setInputFiles([
+    {
+      name: "protected.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("secret content"),
+    },
+  ]);
+  await expect(page.locator("#upload-result .message-body")).toHaveText(
+    "Upload complete!"
+  );
+
+  // Click Files and open the file view link
+  await page.getByRole("menuitem", { name: "Files" }).click();
+  const matchingRow = await page.getByRole("row").filter({ hasText: "protected.txt" });
+  await expect(matchingRow).toBeVisible();
+
+  // Open the file detail (click filename link)
+  await matchingRow.getByRole("link", { name: "protected.txt" }).click();
+
+  // We should see the passphrase prompt page
+  await expect(page.getByRole("heading", { name: "Enter passphrase" })).toBeVisible();
+  await expect(page.getByText("private note - should not appear on prompt")).toHaveCount(0);
+
+  // Try wrong passphrase first
+  await page.locator('input[name="passphrase"]').fill("wrong");
+  await page.getByRole("button", { name: "View" }).click();
+  await expect(page.getByText("Incorrect passphrase")).toBeVisible();
+
+  // Now enter the correct passphrase
+  await page.locator('input[name="passphrase"]').fill("letmein");
+  await page.getByRole("button", { name: "View" }).click();
+
+  // Content should be visible
+  await expect(page.locator("pre")).toHaveText("secret content");
+
+  // Also verify the query param path works: open short link with ?passphrase=
+  // First, go back to files and get the verbose link from the info page
+  await page.goBack();
+  // Re-seleccionar la fila tras navegar
+  const rowAfterBack = await page
+    .getByRole("row")
+    .filter({ hasText: "protected.txt" });
+  await rowAfterBack.getByRole("button", { name: "Information" }).click();
+  // Copy short link from the UI component
+  const shortLink = await page.evaluate(() => {
+    const uploadLinks = document.querySelector(
+      "upload-links"
+    ) as HTMLElement & { shadowRoot: ShadowRoot | null };
+    const shortBox = uploadLinks?.shadowRoot?.querySelector(
+      "#short-link-box"
+    ) as HTMLElement & { shadowRoot: ShadowRoot | null };
+    const a = shortBox?.shadowRoot?.querySelector(
+      "#link"
+    ) as HTMLAnchorElement | null;
+    return a?.href || "";
+  });
+
+  // Open link in same page with passphrase param
+  await page.goto(shortLink + "?passphrase=letmein");
+  await expect(page.locator("pre")).toHaveText("secret content");
+});

--- a/e2e/passphrase.spec.ts
+++ b/e2e/passphrase.spec.ts
@@ -4,11 +4,16 @@ import { login } from "./helpers/login";
 // Reuse columns mapping from upload.spec where needed
 const noteColumn = 1;
 
-test("uploads a file with a passphrase and requires it on download", async ({ page, request }) => {
+test("uploads a file with a passphrase and requires it on download", async ({
+  page,
+  request,
+}) => {
   await login(page);
 
   // Set a note just to ensure it doesn't leak into the prompt page.
-  await page.locator("#note").fill("private note - should not appear on prompt");
+  await page
+    .locator("#note")
+    .fill("private note - should not appear on prompt");
   await page.locator("#passphrase").fill("letmein");
 
   await page.locator(".file-input").setInputFiles([
@@ -39,14 +44,18 @@ test("uploads a file with a passphrase and requires it on download", async ({ pa
 
   // Click Files and open the file view link
   await page.getByRole("menuitem", { name: "Files" }).click();
-  const matchingRow = await page.getByRole("row").filter({ hasText: "protected.txt" });
+  const matchingRow = await page
+    .getByRole("row")
+    .filter({ hasText: "protected.txt" });
   await expect(matchingRow).toBeVisible();
 
   // Open the file detail (click filename link)
   await matchingRow.getByRole("link", { name: "protected.txt" }).click();
 
   // We should see the passphrase prompt page
-  await expect(page.getByRole("heading", { name: "Enter passphrase" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Enter passphrase" })
+  ).toBeVisible();
 
   // Try wrong passphrase first
   await page.locator('input[name="passphrase"]').fill("wrong");
@@ -60,11 +69,12 @@ test("uploads a file with a passphrase and requires it on download", async ({ pa
   // Content should be visible
   await expect(page.locator("pre")).toHaveText("secret content");
 
-  // Also verify the query param path works: open short link with ?passphrase=
-  // First, go back to files and get the verbose link from the info page
-  await page.goBack();
-
-  // Open link in same page with passphrase param
-  await page.goto(shortLink + "?passphrase=letmein");
+  // Also verify short link flow: open short link, then submit the form
+  await page.goto(shortLink);
+  await expect(
+    page.getByRole("heading", { name: "Enter passphrase" })
+  ).toBeVisible();
+  await page.locator('input[name="passphrase"]').fill("letmein");
+  await page.getByRole("button", { name: "View" }).click();
   await expect(page.locator("pre")).toHaveText("secret content");
 });

--- a/handlers/auth/shared_secret/shared_secret.go
+++ b/handlers/auth/shared_secret/shared_secret.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/mtlynch/picoshare/v2/handlers/auth/shared_secret/kdf"
+	"github.com/mtlynch/picoshare/v2/kdf"
 )
 
 const authCookieName = "sharedSecret"

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -40,7 +40,7 @@ func (s Server) entryGet() http.HandlerFunc {
 		}
 
 		// If entry requires passphrase, render prompt page.
-	if !entry.PassphraseKey.IsZero() {
+		if !entry.PassphraseKey.IsZero() {
 			renderPassphrasePrompt(tPass, w, r, id, entry)
 			return
 		}

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/mtlynch/picoshare/v2/handlers"
-	"github.com/mtlynch/picoshare/v2/handlers/auth/shared_secret/kdf"
+	"github.com/mtlynch/picoshare/v2/kdf"
 	"github.com/mtlynch/picoshare/v2/picoshare"
 	"github.com/mtlynch/picoshare/v2/store/test_sqlite"
 )
@@ -205,10 +205,6 @@ func TestEntryAccessPost_PassphraseFlows(t *testing.T) {
 }
 
 // helpers
-func handlers_kdf_Derive(secret string) (string, error) {
-	k, err := kdf.DeriveKeyFromSecret(secret)
-	if err != nil {
-		return "", err
-	}
-	return k.Serialize(), nil
+func handlers_kdf_Derive(secret string) (kdf.DerivedKey, error) {
+	return kdf.DeriveKeyFromSecret(secret)
 }

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -61,6 +61,9 @@ func (s *Server) routes() {
 	views.HandleFunc("/login", s.authGet()).Methods(http.MethodGet)
 	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	// Allow POST to same path to submit passphrase form
+	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodPost)
+	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodPost)
 	// Legacy routes for entries. We stopped using them because the ! has
 	// unintended side effects within the bash shell.
 	views.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -61,9 +61,8 @@ func (s *Server) routes() {
 	views.HandleFunc("/login", s.authGet()).Methods(http.MethodGet)
 	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
-	// Allow POST to same path to submit passphrase form
-	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodPost)
-	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodPost)
+	views.PathPrefix("/-{id}").HandlerFunc(s.entryAccessPost()).Methods(http.MethodPost)
+	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryAccessPost()).Methods(http.MethodPost)
 	// Legacy routes for entries. We stopped using them because the ! has
 	// unintended side effects within the bash shell.
 	views.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)

--- a/handlers/static/js/controllers/files.js
+++ b/handlers/static/js/controllers/files.js
@@ -44,7 +44,13 @@ function uploadFormData(url, formData, progressFn) {
     });
 }
 
-export async function uploadFile(file, expirationTime, note, passphrase, progressFn) {
+export async function uploadFile(
+  file,
+  expirationTime,
+  note,
+  passphrase,
+  progressFn
+) {
   const formData = new FormData();
   formData.append("file", file);
   if (note) {

--- a/handlers/static/js/controllers/files.js
+++ b/handlers/static/js/controllers/files.js
@@ -44,11 +44,14 @@ function uploadFormData(url, formData, progressFn) {
     });
 }
 
-export async function uploadFile(file, expirationTime, note, progressFn) {
+export async function uploadFile(file, expirationTime, note, passphrase, progressFn) {
   const formData = new FormData();
   formData.append("file", file);
   if (note) {
     formData.append("note", note);
+  }
+  if (passphrase) {
+    formData.append("passphrase", passphrase);
   }
   return uploadFormData(
     `/api/entry?expiration=${encodeURIComponent(expirationTime)}`,
@@ -61,10 +64,14 @@ export async function guestUploadFile(
   file,
   guestLinkID,
   expirationTime,
+  passphrase,
   progressFn
 ) {
   const formData = new FormData();
   formData.append("file", file);
+  if (passphrase) {
+    formData.append("passphrase", passphrase);
+  }
   return uploadFormData(
     `/api/guest/${guestLinkID}?expiration=${encodeURIComponent(
       expirationTime

--- a/handlers/store.go
+++ b/handlers/store.go
@@ -12,9 +12,6 @@ type Store interface {
 	GetEntryMetadata(id picoshare.EntryID) (picoshare.UploadMetadata, error)
 	InsertEntry(reader io.Reader, metadata picoshare.UploadMetadata) error
 	UpdateEntryMetadata(id picoshare.EntryID, metadata picoshare.UploadMetadata) error
-	// UpdateEntryPassphrase sets or clears the passphrase key. If passphraseKeySerialized is nil,
-	// the passphrase protection is removed. If non-nil, sets the passphrase to the provided key.
-	// When no change is needed, callers should avoid invoking this method.
 	UpdateEntryPassphrase(id picoshare.EntryID, passphraseKeySerialized *string) error
 	DeleteEntry(id picoshare.EntryID) error
 	GetGuestLink(picoshare.GuestLinkID) (picoshare.GuestLink, error)

--- a/handlers/store.go
+++ b/handlers/store.go
@@ -12,6 +12,10 @@ type Store interface {
 	GetEntryMetadata(id picoshare.EntryID) (picoshare.UploadMetadata, error)
 	InsertEntry(reader io.Reader, metadata picoshare.UploadMetadata) error
 	UpdateEntryMetadata(id picoshare.EntryID, metadata picoshare.UploadMetadata) error
+	// UpdateEntryPassphrase sets or clears the passphrase key. If passphraseKeySerialized is nil,
+	// the passphrase protection is removed. If non-nil, sets the passphrase to the provided key.
+	// When no change is needed, callers should avoid invoking this method.
+	UpdateEntryPassphrase(id picoshare.EntryID, passphraseKeySerialized *string) error
 	DeleteEntry(id picoshare.EntryID) error
 	GetGuestLink(picoshare.GuestLinkID) (picoshare.GuestLink, error)
 	GetGuestLinks() ([]picoshare.GuestLink, error)

--- a/handlers/templates/pages/file-edit.html
+++ b/handlers/templates/pages/file-edit.html
@@ -15,7 +15,7 @@
     }
 
     function readNote() {
-      return document.getElementById("note").value || null;
+      return document.getElementById("note").value || "";
     }
 
     document.getElementById("cancel-btn").addEventListener("click", () => {
@@ -44,7 +44,7 @@
         note: readNote(),
       };
       if (clearPP) {
-        payload.passphraseAction = "clear";
+        payload.passphrase = ""; // empty string indicates clearing passphrase
       } else if (ppInput.value) {
         payload.passphrase = ppInput.value;
       }

--- a/handlers/templates/pages/file-edit.html
+++ b/handlers/templates/pages/file-edit.html
@@ -22,7 +22,7 @@
       history.back();
     });
 
-    document.getElementById("edit-form").addEventListener("submit", (evt) => {
+  document.getElementById("edit-form").addEventListener("submit", (evt) => {
       evt.preventDefault();
       const id = document
         .getElementById("edit-form")
@@ -35,7 +35,25 @@
       hideElement(editForm);
       showElement(progressSpinner);
 
-      editFile(id, readFilename(), expirationPicker.value, readNote())
+      const ppInput = document.getElementById("passphrase");
+      const clearPP = document.getElementById("clear-passphrase").checked;
+
+      const payload = {
+        filename: readFilename(),
+        expiration: expirationPicker.value,
+        note: readNote(),
+      };
+      if (clearPP) {
+        payload.passphraseAction = "clear";
+      } else if (ppInput.value) {
+        payload.passphrase = ppInput.value;
+      }
+
+      fetch(`/api/entry/${encodeURIComponent(id)}`, {
+        method: "PUT",
+        credentials: "include",
+        body: JSON.stringify(payload),
+      })
         .then(() => {
           document.location = "/files";
         })
@@ -100,6 +118,24 @@
             disabled
           {{ end }}
         />
+      </div>
+
+      <div class="field my-5">
+        <label class="label">Passphrase</label>
+        <div class="control">
+          <input
+            id="passphrase"
+            class="input is-normal"
+            type="password"
+            placeholder="Set or change passphrase"
+            autocomplete="new-password"
+          />
+        </div>
+        <label class="checkbox mt-2">
+          <input type="checkbox" id="clear-passphrase" />
+          Clear existing passphrase
+        </label>
+        <p class="help">Leave empty to keep current. Check to clear protection.</p>
       </div>
 
       <div class="field my-5">

--- a/handlers/templates/pages/file-edit.html
+++ b/handlers/templates/pages/file-edit.html
@@ -22,7 +22,7 @@
       history.back();
     });
 
-  document.getElementById("edit-form").addEventListener("submit", (evt) => {
+    document.getElementById("edit-form").addEventListener("submit", (evt) => {
       evt.preventDefault();
       const id = document
         .getElementById("edit-form")
@@ -135,7 +135,9 @@
           <input type="checkbox" id="clear-passphrase" />
           Clear existing passphrase
         </label>
-        <p class="help">Leave empty to keep current. Check to clear protection.</p>
+        <p class="help">
+          Leave empty to keep current. Check to clear protection.
+        </p>
       </div>
 
       <div class="field my-5">

--- a/handlers/templates/pages/file-protected.html
+++ b/handlers/templates/pages/file-protected.html
@@ -1,0 +1,38 @@
+{{ define "content" }}
+  <h1 class="title">Enter passphrase</h1>
+
+  {{ if .Error }}
+    <div class="my-3">
+      <article class="message is-danger">
+        <div class="message-body">{{ .Error }}</div>
+      </article>
+    </div>
+  {{ end }}
+
+
+  <form method="post" action="{{ .PostURL }}" class="mb-2">
+    <div class="field">
+      <label class="label">Passphrase</label>
+      <div class="control">
+        <input
+          class="input"
+          name="passphrase"
+          type="password"
+          required
+          autofocus
+          placeholder="Passphrase"
+        />
+      </div>
+    </div>
+    {{ if .Filename }}
+      <p>File: <span class="has-text-grey-dark">{{ .Filename }}</span></p>
+    {{ end }}
+
+
+    <div class="field mt-4">
+      <div class="control">
+        <button class="button is-primary" type="submit">View</button>
+      </div>
+    </div>
+  </form>
+{{ end }}

--- a/handlers/templates/pages/upload.html
+++ b/handlers/templates/pages/upload.html
@@ -35,7 +35,8 @@
     const expirationSelect = document.getElementById("expiration-select");
     const expirationPicker = document.getElementById("expiration-picker");
     const noteInput = document.getElementById("note");
-    const uploadAnotherBtn = document.getElementById("upload-another-btn");
+  const uploadAnotherBtn = document.getElementById("upload-another-btn");
+  const passphraseInput = document.getElementById("passphrase");
 
     function getGuestLinkMetdata() {
       const el = document.getElementById("guest-link-metadata");
@@ -61,7 +62,7 @@
       return noteInput.value || null;
     }
 
-    function populateEditButton(entryId) {
+  function populateEditButton(entryId) {
       const btn = document.getElementById("edit-btn");
       // Button does not appear in guest mode.
       if (!btn) {
@@ -83,7 +84,7 @@
       }
     }
 
-    function doUpload(file) {
+  function doUpload(file) {
       const guestLinkMetadata = getGuestLinkMetdata();
 
       if (
@@ -103,7 +104,13 @@
       showElement(progressBar);
 
       let uploader = () => {
-        return uploadFile(file, readExpiration(), readNote(), updateProgress);
+        return uploadFile(
+          file,
+          readExpiration(),
+          readNote(),
+          passphraseInput ? passphraseInput.value : null,
+          updateProgress
+        );
       };
       if (guestLinkMetadata) {
         uploader = () => {
@@ -111,6 +118,7 @@
             file,
             guestLinkMetadata.id,
             readExpiration(),
+            passphraseInput ? passphraseInput.value : null,
             updateProgress
           );
         };
@@ -328,6 +336,20 @@
         <p class="help">Note is only visible to you</p>
       </div>
     {{ end }}
+
+    <div class="field my-5">
+      <label class="label">Passphrase <i>(optional)</i></label>
+      <div class="control">
+        <input
+          id="passphrase"
+          class="input is-normal"
+          type="password"
+          placeholder="Enter a passphrase to require before viewing"
+          autocomplete="new-password"
+        />
+      </div>
+      <p class="help">Viewers must enter this passphrase to access the file. The file content is not encrypted.</p>
+    </div>
   </div>
 
   <progress

--- a/handlers/templates/pages/upload.html
+++ b/handlers/templates/pages/upload.html
@@ -35,8 +35,8 @@
     const expirationSelect = document.getElementById("expiration-select");
     const expirationPicker = document.getElementById("expiration-picker");
     const noteInput = document.getElementById("note");
-  const uploadAnotherBtn = document.getElementById("upload-another-btn");
-  const passphraseInput = document.getElementById("passphrase");
+    const uploadAnotherBtn = document.getElementById("upload-another-btn");
+    const passphraseInput = document.getElementById("passphrase");
 
     function getGuestLinkMetdata() {
       const el = document.getElementById("guest-link-metadata");
@@ -62,7 +62,7 @@
       return noteInput.value || null;
     }
 
-  function populateEditButton(entryId) {
+    function populateEditButton(entryId) {
       const btn = document.getElementById("edit-btn");
       // Button does not appear in guest mode.
       if (!btn) {
@@ -84,7 +84,7 @@
       }
     }
 
-  function doUpload(file) {
+    function doUpload(file) {
       const guestLinkMetadata = getGuestLinkMetdata();
 
       if (
@@ -337,6 +337,7 @@
       </div>
     {{ end }}
 
+
     <div class="field my-5">
       <label class="label">Passphrase <i>(optional)</i></label>
       <div class="control">
@@ -348,7 +349,10 @@
           autocomplete="new-password"
         />
       </div>
-      <p class="help">Viewers must enter this passphrase to access the file. The file content is not encrypted.</p>
+      <p class="help">
+        Viewers must enter this passphrase to access the file. The file content
+        is not encrypted.
+      </p>
     </div>
   </div>
 

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -197,11 +197,10 @@ type entryEdit struct {
 // by either a non-nil PassphraseSet (to set/update) or PassphraseClear=true to clear.
 func (s Server) entryEditFromRequest(r *http.Request) (entryEdit, error) {
 	var payload struct {
-		Filename         string  `json:"filename"`
-		Expiration       string  `json:"expiration"`
-		Note             string  `json:"note"`
-		Passphrase       *string `json:"passphrase"`
-		PassphraseAction string  `json:"passphraseAction"`
+		Filename   string  `json:"filename"`
+		Expiration string  `json:"expiration"`
+		Note       string  `json:"note"`
+		Passphrase *string `json:"passphrase"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		log.Printf("failed to decode JSON request: %v", err)
@@ -234,9 +233,7 @@ func (s Server) entryEditFromRequest(r *http.Request) (entryEdit, error) {
 		},
 	}
 
-	if payload.PassphraseAction == "clear" {
-		e.PassphraseClear = true
-	} else if payload.Passphrase != nil {
+	if payload.Passphrase != nil {
 		if *payload.Passphrase == "" {
 			e.PassphraseClear = true
 		} else {

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -9,8 +9,8 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
-	"github.com/mtlynch/picoshare/v2/kdf"
 	"github.com/mtlynch/picoshare/v2/handlers/parse"
+	"github.com/mtlynch/picoshare/v2/kdf"
 	"github.com/mtlynch/picoshare/v2/picoshare"
 	"github.com/mtlynch/picoshare/v2/random"
 	"github.com/mtlynch/picoshare/v2/store"
@@ -101,7 +101,7 @@ func (s Server) entryPut() http.HandlerFunc {
 				http.Error(w, "Failed to update passphrase", http.StatusInternalServerError)
 				return
 			}
-	} else if edit.PassphraseSet != nil {
+		} else if edit.PassphraseSet != nil {
 			key, err := kdf.DeriveKeyFromSecret(*edit.PassphraseSet)
 			if err != nil {
 				http.Error(w, "Invalid passphrase", http.StatusBadRequest)

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -81,11 +81,11 @@ func (s Server) entryPut() http.HandlerFunc {
 		// Passphrase change is specified with either passphrase (string) to set/update,
 		// or passphraseAction:"clear" to remove.
 		type editPayload struct {
-			Filename        string `json:"filename"`
-			Expiration      string `json:"expiration"`
-			Note            string `json:"note"`
-			Passphrase      *string `json:"passphrase"`
-			PassphraseAction string `json:"passphraseAction"`
+			Filename         string  `json:"filename"`
+			Expiration       string  `json:"expiration"`
+			Note             string  `json:"note"`
+			Passphrase       *string `json:"passphrase"`
+			PassphraseAction string  `json:"passphraseAction"`
 		}
 		var ep editPayload
 		if err := json.NewDecoder(r.Body).Decode(&ep); err != nil {
@@ -323,9 +323,9 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 			GuestLink: picoshare.GuestLink{
 				ID: guestLinkID,
 			},
-			Uploaded: s.clock.Now(),
-			Expires:  expiration,
-			Size:     fileSize,
+			Uploaded:      s.clock.Now(),
+			Expires:       expiration,
+			Size:          fileSize,
 			PassphraseKey: serializedKey,
 		})
 	if err != nil {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -310,7 +310,7 @@ func TestEntryPut_PassphraseTransitions(t *testing.T) {
 		t.Fatalf("expected 200 when setting passphrase, got %d", rec.Result().StatusCode)
 	}
 	meta, _ := dataStore.GetEntryMetadata(original.ID)
-	if meta.PassphraseKey == "" {
+	if meta.PassphraseKey.IsZero() {
 		t.Fatalf("expected passphrase key to be set")
 	}
 
@@ -324,7 +324,7 @@ func TestEntryPut_PassphraseTransitions(t *testing.T) {
 		t.Fatalf("expected 200 when updating passphrase, got %d", rec.Result().StatusCode)
 	}
 	meta2, _ := dataStore.GetEntryMetadata(original.ID)
-	if meta2.PassphraseKey == meta.PassphraseKey {
+	if meta2.PassphraseKey.Serialize() == meta.PassphraseKey.Serialize() {
 		t.Fatalf("expected passphrase key to change when updated")
 	}
 
@@ -338,7 +338,7 @@ func TestEntryPut_PassphraseTransitions(t *testing.T) {
 		t.Fatalf("expected 200 when clearing passphrase, got %d", rec.Result().StatusCode)
 	}
 	meta3, _ := dataStore.GetEntryMetadata(original.ID)
-	if meta3.PassphraseKey != "" {
+	if !meta3.PassphraseKey.IsZero() {
 		t.Fatalf("expected passphrase key to be cleared")
 	}
 }

--- a/kdf/kdf.go
+++ b/kdf/kdf.go
@@ -1,0 +1,76 @@
+package kdf
+
+import (
+    "crypto/sha256"
+    "crypto/subtle"
+    "encoding/base64"
+    "errors"
+
+    "golang.org/x/crypto/pbkdf2"
+)
+
+var (
+    // ErrInvalidSecret indicates that the provided secret is empty or invalid.
+    ErrInvalidSecret = errors.New("invalid shared secret")
+    // ErrInvalidSerialization indicates that the serialized data is invalid.
+    ErrInvalidSerialization = errors.New("invalid serialized key data")
+)
+
+// DeriveKeyFromSecret creates a derived key from the provided secret string
+// using PBKDF2 with hardcoded parameters.
+func DeriveKeyFromSecret(secret string) (DerivedKey, error) {
+    if secret == "" {
+        return DerivedKey{}, ErrInvalidSecret
+    }
+
+    // These would be insecure values for storing a database of user credentials,
+    // but we're only storing a single password, so it's not important to have
+    // random salt or high iteration rounds.
+    salt := []byte{1, 2, 3, 4}
+    iter := 100
+    keyLength := 32
+
+    keyData := pbkdf2.Key([]byte(secret), salt, iter, keyLength, sha256.New)
+    return DerivedKey{data: keyData}, nil
+}
+
+// DerivedKey represents key material derived from a key derivation function.
+type DerivedKey struct {
+    data []byte
+}
+
+// IsZero reports whether the key has no data (i.e., uninitialized/empty).
+func (k DerivedKey) IsZero() bool {
+    return len(k.data) == 0
+}
+
+// Equal performs constant-time comparison between this key and another key.
+func (k DerivedKey) Equal(other DerivedKey) bool {
+    // If either side is zero, only consider equal if both are zero.
+    if len(k.data) == 0 || len(other.data) == 0 {
+        return len(k.data) == 0 && len(other.data) == 0
+    }
+    return subtle.ConstantTimeCompare(k.data, other.data) != 0
+}
+
+// Serialize returns the base64-encoded representation of the derived key.
+func (k DerivedKey) Serialize() string {
+    if len(k.data) == 0 {
+        panic("can't serialize uninitialized DerivedKey")
+    }
+    return base64.StdEncoding.EncodeToString(k.data)
+}
+
+// DeserializeKey creates a DerivedKey from a base64-encoded string.
+func DeserializeKey(base64Data string) (DerivedKey, error) {
+    if base64Data == "" {
+        return DerivedKey{}, ErrInvalidSerialization
+    }
+
+    decoded, err := base64.StdEncoding.DecodeString(base64Data)
+    if err != nil {
+        return DerivedKey{}, ErrInvalidSerialization
+    }
+
+    return DerivedKey{data: decoded}, nil
+}

--- a/kdf/kdf.go
+++ b/kdf/kdf.go
@@ -1,76 +1,76 @@
 package kdf
 
 import (
-    "crypto/sha256"
-    "crypto/subtle"
-    "encoding/base64"
-    "errors"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
 
-    "golang.org/x/crypto/pbkdf2"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 var (
-    // ErrInvalidSecret indicates that the provided secret is empty or invalid.
-    ErrInvalidSecret = errors.New("invalid shared secret")
-    // ErrInvalidSerialization indicates that the serialized data is invalid.
-    ErrInvalidSerialization = errors.New("invalid serialized key data")
+	// ErrInvalidSecret indicates that the provided secret is empty or invalid.
+	ErrInvalidSecret = errors.New("invalid shared secret")
+	// ErrInvalidSerialization indicates that the serialized data is invalid.
+	ErrInvalidSerialization = errors.New("invalid serialized key data")
 )
 
 // DeriveKeyFromSecret creates a derived key from the provided secret string
 // using PBKDF2 with hardcoded parameters.
 func DeriveKeyFromSecret(secret string) (DerivedKey, error) {
-    if secret == "" {
-        return DerivedKey{}, ErrInvalidSecret
-    }
+	if secret == "" {
+		return DerivedKey{}, ErrInvalidSecret
+	}
 
-    // These would be insecure values for storing a database of user credentials,
-    // but we're only storing a single password, so it's not important to have
-    // random salt or high iteration rounds.
-    salt := []byte{1, 2, 3, 4}
-    iter := 100
-    keyLength := 32
+	// These would be insecure values for storing a database of user credentials,
+	// but we're only storing a single password, so it's not important to have
+	// random salt or high iteration rounds.
+	salt := []byte{1, 2, 3, 4}
+	iter := 100
+	keyLength := 32
 
-    keyData := pbkdf2.Key([]byte(secret), salt, iter, keyLength, sha256.New)
-    return DerivedKey{data: keyData}, nil
+	keyData := pbkdf2.Key([]byte(secret), salt, iter, keyLength, sha256.New)
+	return DerivedKey{data: keyData}, nil
 }
 
 // DerivedKey represents key material derived from a key derivation function.
 type DerivedKey struct {
-    data []byte
+	data []byte
 }
 
 // IsZero reports whether the key has no data (i.e., uninitialized/empty).
 func (k DerivedKey) IsZero() bool {
-    return len(k.data) == 0
+	return len(k.data) == 0
 }
 
 // Equal performs constant-time comparison between this key and another key.
 func (k DerivedKey) Equal(other DerivedKey) bool {
-    // If either side is zero, only consider equal if both are zero.
-    if len(k.data) == 0 || len(other.data) == 0 {
-        return len(k.data) == 0 && len(other.data) == 0
-    }
-    return subtle.ConstantTimeCompare(k.data, other.data) != 0
+	// If either side is zero, only consider equal if both are zero.
+	if len(k.data) == 0 || len(other.data) == 0 {
+		return len(k.data) == 0 && len(other.data) == 0
+	}
+	return subtle.ConstantTimeCompare(k.data, other.data) != 0
 }
 
 // Serialize returns the base64-encoded representation of the derived key.
 func (k DerivedKey) Serialize() string {
-    if len(k.data) == 0 {
-        panic("can't serialize uninitialized DerivedKey")
-    }
-    return base64.StdEncoding.EncodeToString(k.data)
+	if len(k.data) == 0 {
+		panic("can't serialize uninitialized DerivedKey")
+	}
+	return base64.StdEncoding.EncodeToString(k.data)
 }
 
 // DeserializeKey creates a DerivedKey from a base64-encoded string.
 func DeserializeKey(base64Data string) (DerivedKey, error) {
-    if base64Data == "" {
-        return DerivedKey{}, ErrInvalidSerialization
-    }
+	if base64Data == "" {
+		return DerivedKey{}, ErrInvalidSerialization
+	}
 
-    decoded, err := base64.StdEncoding.DecodeString(base64Data)
-    if err != nil {
-        return DerivedKey{}, ErrInvalidSerialization
-    }
+	decoded, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		return DerivedKey{}, ErrInvalidSerialization
+	}
 
-    return DerivedKey{data: decoded}, nil
+	return DerivedKey{data: decoded}, nil
 }

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -3,6 +3,8 @@ package picoshare
 import (
 	"io"
 	"time"
+
+	"github.com/mtlynch/picoshare/v2/kdf"
 )
 
 type (
@@ -25,9 +27,9 @@ type (
 		Size          FileSize
 		GuestLink     GuestLink
 		DownloadCount uint64
-		// PassphraseKey stores a serialized kdf.DerivedKey if the uploader
-		// protected the file with a passphrase. Empty means no protection.
-		PassphraseKey string
+		// PassphraseKey stores a derived key if the uploader protected the file
+		// with a passphrase. Zero-value means no protection.
+		PassphraseKey kdf.DerivedKey
 	}
 
 	DownloadRecord struct {

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -25,6 +25,9 @@ type (
 		Size          FileSize
 		GuestLink     GuestLink
 		DownloadCount uint64
+	// PassphraseKey stores a serialized kdf.DerivedKey if the uploader
+	// protected the file with a passphrase. Empty means no protection.
+	PassphraseKey string
 	}
 
 	DownloadRecord struct {

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -25,9 +25,9 @@ type (
 		Size          FileSize
 		GuestLink     GuestLink
 		DownloadCount uint64
-	// PassphraseKey stores a serialized kdf.DerivedKey if the uploader
-	// protected the file with a passphrase. Empty means no protection.
-	PassphraseKey string
+		// PassphraseKey stores a serialized kdf.DerivedKey if the uploader
+		// protected the file with a passphrase. Empty means no protection.
+		PassphraseKey string
 	}
 
 	DownloadRecord struct {

--- a/store/sqlite/entries.go
+++ b/store/sqlite/entries.go
@@ -53,9 +53,9 @@ func (s Store) GetEntriesMetadata() ([]picoshare.UploadMetadata, error) {
 		var contentType string
 		var uploadTimeRaw string
 		var expirationTimeRaw string
-	var fileSizeRaw uint64
-	var passphraseKey *string
-	if err = rows.Scan(&id, &filename, &note, &contentType, &uploadTimeRaw, &expirationTimeRaw, &fileSizeRaw, &passphraseKey); err != nil {
+		var fileSizeRaw uint64
+		var passphraseKey *string
+		if err = rows.Scan(&id, &filename, &note, &contentType, &uploadTimeRaw, &expirationTimeRaw, &fileSizeRaw, &passphraseKey); err != nil {
 			return []picoshare.UploadMetadata{}, err
 		}
 
@@ -82,7 +82,12 @@ func (s Store) GetEntriesMetadata() ([]picoshare.UploadMetadata, error) {
 			Uploaded:    ut,
 			Expires:     picoshare.ExpirationTime(et),
 			Size:        fileSize,
-			PassphraseKey: func() string { if passphraseKey != nil { return *passphraseKey }; return "" }(),
+			PassphraseKey: func() string {
+				if passphraseKey != nil {
+					return *passphraseKey
+				}
+				return ""
+			}(),
 		})
 	}
 
@@ -106,7 +111,7 @@ func (s Store) GetEntryMetadata(id picoshare.EntryID) (picoshare.UploadMetadata,
 	var expirationTimeRaw string
 	var fileSizeRaw uint64
 	var guestLinkID *picoshare.GuestLinkID
-    var passphraseKey *string
+	var passphraseKey *string
 	err := s.ctx.QueryRow(`
 	SELECT
 		entries.filename AS filename,
@@ -168,8 +173,13 @@ func (s Store) GetEntryMetadata(id picoshare.EntryID) (picoshare.UploadMetadata,
 		ContentType: picoshare.ContentType(contentType),
 		Uploaded:    ut,
 		Expires:     picoshare.ExpirationTime(et),
-	Size:        fileSize,
-	PassphraseKey: func() string { if passphraseKey != nil { return *passphraseKey }; return "" }(),
+		Size:        fileSize,
+		PassphraseKey: func() string {
+			if passphraseKey != nil {
+				return *passphraseKey
+			}
+			return ""
+		}(),
 	}, nil
 }
 

--- a/store/sqlite/entries.go
+++ b/store/sqlite/entries.go
@@ -11,12 +11,6 @@ import (
 	"github.com/mtlynch/picoshare/v2/store/sqlite/file"
 )
 
-func nullIfEmpty(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
-}
 
 func (s Store) GetEntriesMetadata() ([]picoshare.UploadMetadata, error) {
 	rows, err := s.ctx.Query(`
@@ -213,7 +207,7 @@ func (s Store) InsertEntry(reader io.Reader, metadata picoshare.UploadMetadata) 
 		expiration_time,
 		passphrase_key
 	)
-	VALUES(:entry_id, NULLIF(:guest_link_id, ''), :filename, :note, :content_type, :upload_time, :expiration_time, :passphrase_key)`,
+	VALUES(:entry_id, NULLIF(:guest_link_id, ''), :filename, :note, :content_type, :upload_time, :expiration_time, NULLIF(:passphrase_key, ''))`,
 		sql.Named("entry_id", metadata.ID),
 		sql.Named("guest_link_id", metadata.GuestLink.ID),
 		sql.Named("filename", metadata.Filename),
@@ -221,7 +215,7 @@ func (s Store) InsertEntry(reader io.Reader, metadata picoshare.UploadMetadata) 
 		sql.Named("content_type", metadata.ContentType),
 		sql.Named("upload_time", formatTime(metadata.Uploaded)),
 		sql.Named("expiration_time", formatExpirationTime(metadata.Expires)),
-		sql.Named("passphrase_key", nullIfEmpty(metadata.PassphraseKey)),
+		sql.Named("passphrase_key", metadata.PassphraseKey),
 	)
 	if err != nil {
 		log.Printf("insert into entries table failed, aborting transaction: %v", err)

--- a/store/sqlite/migrations/016-add-entries-passphrase-key.sql
+++ b/store/sqlite/migrations/016-add-entries-passphrase-key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries ADD COLUMN passphrase_key TEXT;


### PR DESCRIPTION
Made with AI so let's review this.

This PR adds optional **passphrase protection** to PicoShare entries:

* Set a passphrase on upload (owner & guest uploads).
* Change or clear the passphrase from the file edit page.
* Prompt viewers to enter the passphrase before accessing the file.

> **Note:** This feature is **access control only**. File contents are **not encrypted at rest**.

## Implementation details

* DB: `entries.passphrase_key TEXT` (nullable). Migration included.
* Backend:

  * Store interface gains `UpdateEntryPassphrase(id, *string)`.
  * Upload/edit handlers accept a passphrase and persist its derived key.
  * Download handler prompts for passphrase and verifies it before serving.
* Frontend:

  * Upload form: optional passphrase field.
  * Edit form: set/change passphrase, or clear protection.

## Security & UX

* Passphrase is submitted via **POST** only (no query string).
* Derived key is **not** exposed in API responses (`json:"-"`).
* Passphrase prompt view is not cached (`Cache-Control: no-store`).
* Error messages are generic (“Incorrect passphrase”).

## Migration

* New migration: `016-add-entries-passphrase-key.sql`

  * Adds nullable `passphrase_key` column.
  * Backwards compatible; existing entries remain unprotected.

## Limitations / Future work

* Consider rate limiting attempts per entry/IP.
* Optional CSRF token for passphrase form.
* Styling for password page

#338 (WIP)