### PR TITLE
parseExpirationFromRequest: treat empty expiration string as NeverExpire

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -289,6 +289,9 @@ func parseContentType(s string) (picoshare.ContentType, error) {
 }
 
 func (s Server) parseExpirationFromRequest(r *http.Request) (picoshare.ExpirationTime, error) {
+	if r.URL.Query().Get("expiration") == "" {
+		return picoshare.NeverExpire, nil
+	}
 	return parse.Expiration(r.URL.Query().Get("expiration"), s.clock.Now())
 }
 


### PR DESCRIPTION
When the expiration query parameter is omitted from POST /api/entry, the handler now returns NeverExpire instead of a 400 error. This makes the behavior consistent with the PUT handler and guest upload handler, which both default to NeverExpire when the expiration param is empty.

Fixes #756
