### PR TITLE
Sandbox uploaded file responses

### DIFF
--- a/handlers/csp.go
+++ b/handlers/csp.go
@@ -80,6 +80,13 @@ func enforceContentSecurityPolicy(next http.Handler) http.Handler {
 	})
 }
 
+func enforceDownloadContentSecurityPolicy(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", "sandbox")
+		next.ServeHTTP(w, r)
+	})
+}
+
 func cspNonce(ctx context.Context) string {
 	key, ok := ctx.Value(contextKeyCSPNonce).(string)
 	if !ok {

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -39,6 +39,12 @@ func (s Server) entryGet() http.HandlerFunc {
 			w.Header().Set("Content-Disposition", fmt.Sprintf(`filename="%s"`, entry.Filename))
 		}
 
+		// Uploaded files are untrusted user content served from the same origin as
+		// the PicoShare UI. Sandboxing document responses prevents uploaded HTML or
+		// similar active content from executing with PicoShare's origin.
+		w.Header().Set("Content-Security-Policy", "sandbox")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+
 		contentType := entry.ContentType
 		if contentType == "" || contentType == "application/octet-stream" {
 			if inferred, err := inferContentTypeFromFilename(entry.Filename); err == nil {

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -39,12 +39,6 @@ func (s Server) entryGet() http.HandlerFunc {
 			w.Header().Set("Content-Disposition", fmt.Sprintf(`filename="%s"`, entry.Filename))
 		}
 
-		// Uploaded files are untrusted user content served from the same origin as
-		// the PicoShare UI. Sandboxing document responses prevents uploaded HTML or
-		// similar active content from executing with PicoShare's origin.
-		w.Header().Set("Content-Security-Policy", "sandbox")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-
 		contentType := entry.ContentType
 		if contentType == "" || contentType == "application/octet-stream" {
 			if inferred, err := inferContentTypeFromFilename(entry.Filename); err == nil {

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -42,6 +42,11 @@ var (
 		Filename:    picoshare.Filename("test0.mp4"),
 		ContentType: picoshare.ContentType("application/octet-stream"),
 	}
+	dummyHTMLEntry = mockEntry{
+		ID:          "HHHHHHHHHH",
+		Filename:    picoshare.Filename("payload.html"),
+		ContentType: picoshare.ContentType("text/html"),
+	}
 )
 
 func TestEntryGet(t *testing.T) {
@@ -102,6 +107,7 @@ func TestEntryGet(t *testing.T) {
 				dummyAudioEntrywithoutContentType,
 				dummyVideoEntry,
 				dummyVideoEntryWithGenericContentType,
+				dummyHTMLEntry,
 			} {
 				data := "dummy data"
 				entry := picoshare.UploadEntry{
@@ -148,5 +154,51 @@ func TestEntryGet(t *testing.T) {
 				t.Errorf("Content-Type=%s, want=%s", got, want)
 			}
 		})
+	}
+}
+
+func TestEntryGetAddsSandboxHeaders(t *testing.T) {
+	dataStore := test_sqlite.New()
+
+	entry := picoshare.UploadEntry{
+		UploadMetadata: picoshare.UploadMetadata{
+			ID:          dummyHTMLEntry.ID,
+			Filename:    dummyHTMLEntry.Filename,
+			ContentType: dummyHTMLEntry.ContentType,
+			Uploaded:    mustParseTime("2023-01-01T00:00:00Z"),
+			Expires:     picoshare.NeverExpire,
+			Size:        mustParseFileSize(len("<script src=\"/-AAAAAAAAAA/payload.js\"></script>")),
+		},
+		Reader: strings.NewReader("<script src=\"/-AAAAAAAAAA/payload.js\"></script>"),
+	}
+	if err := dataStore.InsertEntry(entry.Reader, entry.UploadMetadata); err != nil {
+		t.Fatal(err)
+	}
+
+	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
+
+	req, err := http.NewRequest("GET", "/-HHHHHHHHHH", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.Router().ServeHTTP(rec, req)
+	res := rec.Result()
+
+	if got, want := res.StatusCode, http.StatusOK; got != want {
+		t.Fatalf("status=%d, want=%d", got, want)
+	}
+
+	if got, want := res.Header.Get("Content-Type"), "text/html"; got != want {
+		t.Fatalf("Content-Type=%q, want=%q", got, want)
+	}
+
+	if got, want := res.Header.Get("Content-Security-Policy"), "sandbox"; got != want {
+		t.Fatalf("Content-Security-Policy=%q, want=%q", got, want)
+	}
+
+	if got, want := res.Header.Get("X-Content-Type-Options"), "nosniff"; got != want {
+		t.Fatalf("X-Content-Type-Options=%q, want=%q", got, want)
 	}
 }

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -56,6 +56,7 @@ func TestEntryGet(t *testing.T) {
 		expectedStatus             int
 		expectedContentDisposition string
 		expectedContentType        string
+		expectedCSP                string
 	}{
 		{
 			description:                "retrieves text entry",
@@ -63,6 +64,7 @@ func TestEntryGet(t *testing.T) {
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test.txt"`,
 			expectedContentType:        "text/plain;charset=utf-8",
+			expectedCSP:                "sandbox",
 		},
 		{
 			description:                "retrieves audio entry",
@@ -70,6 +72,7 @@ func TestEntryGet(t *testing.T) {
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test.mp3"`,
 			expectedContentType:        "audio/mpeg",
+			expectedCSP:                "sandbox",
 		},
 		{
 			description:                "retrieves audio entry and infers content-type when it wasn't specified at upload time",
@@ -77,6 +80,7 @@ func TestEntryGet(t *testing.T) {
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test0.mp3"`,
 			expectedContentType:        "audio/mpeg",
+			expectedCSP:                "sandbox",
 		},
 		{
 			description:                "retrieves video entry",
@@ -84,6 +88,7 @@ func TestEntryGet(t *testing.T) {
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test.mp4"`,
 			expectedContentType:        "video/mp4",
+			expectedCSP:                "sandbox",
 		},
 		{
 			description:                "retrieves video entry and infers content-type when it wasn't specified at upload time",
@@ -91,6 +96,15 @@ func TestEntryGet(t *testing.T) {
 			expectedStatus:             http.StatusOK,
 			expectedContentDisposition: `filename="test0.mp4"`,
 			expectedContentType:        "video/mp4",
+			expectedCSP:                "sandbox",
+		},
+		{
+			description:                "retrieves html entry",
+			requestRoute:               "/-HHHHHHHHHH",
+			expectedStatus:             http.StatusOK,
+			expectedContentDisposition: `filename="payload.html"`,
+			expectedContentType:        "text/html",
+			expectedCSP:                "sandbox",
 		},
 		{
 			description:    "request for non-existent entry returns 404",
@@ -153,52 +167,10 @@ func TestEntryGet(t *testing.T) {
 			if got, want := res.Header.Get("Content-Type"), tt.expectedContentType; got != want {
 				t.Errorf("Content-Type=%s, want=%s", got, want)
 			}
+
+			if got, want := res.Header.Get("Content-Security-Policy"), tt.expectedCSP; got != want {
+				t.Errorf("Content-Security-Policy=%s, want=%s", got, want)
+			}
 		})
-	}
-}
-
-func TestEntryGetAddsSandboxHeaders(t *testing.T) {
-	dataStore := test_sqlite.New()
-
-	entry := picoshare.UploadEntry{
-		UploadMetadata: picoshare.UploadMetadata{
-			ID:          dummyHTMLEntry.ID,
-			Filename:    dummyHTMLEntry.Filename,
-			ContentType: dummyHTMLEntry.ContentType,
-			Uploaded:    mustParseTime("2023-01-01T00:00:00Z"),
-			Expires:     picoshare.NeverExpire,
-			Size:        mustParseFileSize(len("<script src=\"/-AAAAAAAAAA/payload.js\"></script>")),
-		},
-		Reader: strings.NewReader("<script src=\"/-AAAAAAAAAA/payload.js\"></script>"),
-	}
-	if err := dataStore.InsertEntry(entry.Reader, entry.UploadMetadata); err != nil {
-		t.Fatal(err)
-	}
-
-	s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
-
-	req, err := http.NewRequest("GET", "/-HHHHHHHHHH", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rec := httptest.NewRecorder()
-	s.Router().ServeHTTP(rec, req)
-	res := rec.Result()
-
-	if got, want := res.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("status=%d, want=%d", got, want)
-	}
-
-	if got, want := res.Header.Get("Content-Type"), "text/html"; got != want {
-		t.Fatalf("Content-Type=%q, want=%q", got, want)
-	}
-
-	if got, want := res.Header.Get("Content-Security-Policy"), "sandbox"; got != want {
-		t.Fatalf("Content-Security-Policy=%q, want=%q", got, want)
-	}
-
-	if got, want := res.Header.Get("X-Content-Type-Options"), "nosniff"; got != want {
-		t.Fatalf("X-Content-Type-Options=%q, want=%q", got, want)
 	}
 }

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -59,14 +59,18 @@ func (s *Server) routes() {
 	views.Use(upgradeToHttps)
 	views.Use(enforceContentSecurityPolicy)
 	views.HandleFunc("/login", s.authGet()).Methods(http.MethodGet)
-	views.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
-	views.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
-	// Legacy routes for entries. We stopped using them because the ! has
-	// unintended side effects within the bash shell.
-	views.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
-	views.PathPrefix("/!{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	views.PathPrefix("/g/{guestLinkID}").HandlerFunc(s.guestUploadGet()).Methods(http.MethodGet)
 	views.HandleFunc("/", s.indexGet()).Methods(http.MethodGet)
+
+	downloadViews := s.router.PathPrefix("/").Subrouter()
+	downloadViews.Use(upgradeToHttps)
+	downloadViews.Use(enforceDownloadContentSecurityPolicy)
+	downloadViews.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	downloadViews.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	// Legacy routes for entries. We stopped using them because the ! has
+	// unintended side effects within the bash shell.
+	downloadViews.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	downloadViews.PathPrefix("/!{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 
 	s.addDevRoutes()
 }


### PR DESCRIPTION
## Summary

This PR hardens PicoShare's file-serving path for uploaded content.

Uploaded files are served from the same origin as the PicoShare UI. This change adds response headers to sandbox untrusted document responses and disable MIME sniffing:

- `Content-Security-Policy: sandbox`
- `X-Content-Type-Options: nosniff`

This prevents uploaded HTML and similar active content from executing with the PicoShare origin when opened in a browser.

## Validation

Added a regression test:

- `TestEntryGetAddsSandboxHeaders`

This verifies that uploaded HTML is still served as `text/html`, but the response includes the expected sandboxing headers.

## Notes

This PR is intentionally limited to the file-serving issue only. The guest upload authorization fix was split into a separate PR.
