### PR TITLE
Return early after rejecting inactive guest uploads

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -116,6 +116,7 @@ func (s Server) guestEntryPost() http.HandlerFunc {
 
 		if !gl.IsActive() {
 			http.Error(w, "Guest link is no longer active", http.StatusUnauthorized)
+			return
 		}
 
 		if gl.MaxFileBytes != picoshare.GuestUploadUnlimitedFileSize {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -325,6 +325,20 @@ func TestGuestUpload(t *testing.T) {
 			fileExpirationTimeExpected: picoshare.NeverExpire,
 		},
 		{
+			description: "disabled guest link",
+			guestLinkInStore: picoshare.GuestLink{
+				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
+				Created:         mustParseTime("2024-01-01T00:00:00Z"),
+				UrlExpires:      picoshare.NeverExpire,
+				MaxFileLifetime: picoshare.FileLifetimeInfinite,
+				IsDisabled:      true,
+			},
+			currentTime:                mustParseTime("2024-01-01T00:00:00Z"),
+			url:                        "/api/guest/abcdefgh23456789?expiration=2030-01-01T00:00:00Z",
+			status:                     http.StatusUnauthorized,
+			fileExpirationTimeExpected: picoshare.NeverExpire,
+		},
+		{
 			description: "invalid guest link",
 			guestLinkInStore: picoshare.GuestLink{
 				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
@@ -580,6 +594,19 @@ func TestGuestUpload(t *testing.T) {
 				t.Fatalf("status=%d, want=%d", got, want)
 			}
 
+			entries, err := dataStore.GetEntriesMetadata()
+			if err != nil {
+				t.Fatalf("failed to list entries metadata: %v", err)
+			}
+
+			expectedEntryCount := len(tt.entriesInStore)
+			if tt.status == http.StatusOK {
+				expectedEntryCount++
+			}
+			if got, want := len(entries), expectedEntryCount; got != want {
+				t.Fatalf("entry count=%d, want=%d", got, want)
+			}
+
 			// Only check the response if the request succeeded.
 			if res.StatusCode != http.StatusOK {
 				return
@@ -720,122 +747,6 @@ func TestGuestUploadAcceptHeader(t *testing.T) {
 				if !strings.HasSuffix(bodyStr, "\r\n") {
 					t.Errorf("expected response to end with \\r\\n, got: %v", bodyStr)
 				}
-			}
-		})
-	}
-}
-
-func TestGuestUploadRejectsInactiveGuestLinksWithoutPersisting(t *testing.T) {
-	authenticator, err := shared_secret.New("dummypass")
-	if err != nil {
-		t.Fatalf("failed to create shared secret: %v", err)
-	}
-
-	for _, tt := range []struct {
-		description        string
-		guestLinkInStore   picoshare.GuestLink
-		entriesInStore     []picoshare.UploadEntry
-		expectedEntryCount int
-		expectedStatus     int
-	}{
-		{
-			description: "disabled guest link",
-			guestLinkInStore: picoshare.GuestLink{
-				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
-				Created:         mustParseTime("2024-01-01T00:00:00Z"),
-				UrlExpires:      mustParseExpirationTime("2030-01-02T03:04:25Z"),
-				MaxFileLifetime: picoshare.FileLifetimeInfinite,
-				IsDisabled:      true,
-			},
-			expectedEntryCount: 0,
-			expectedStatus:     http.StatusUnauthorized,
-		},
-		{
-			description: "expired guest link",
-			guestLinkInStore: picoshare.GuestLink{
-				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
-				Created:         mustParseTime("2022-02-21T00:00:00Z"),
-				UrlExpires:      mustParseExpirationTime("2022-02-22T03:04:25Z"),
-				MaxFileLifetime: picoshare.FileLifetimeInfinite,
-			},
-			expectedEntryCount: 0,
-			expectedStatus:     http.StatusUnauthorized,
-		},
-		{
-			description: "upload-count limit reached",
-			guestLinkInStore: picoshare.GuestLink{
-				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
-				Created:         mustParseTime("2024-01-01T00:00:00Z"),
-				UrlExpires:      mustParseExpirationTime("2030-01-02T03:04:25Z"),
-				MaxFileLifetime: picoshare.FileLifetimeInfinite,
-				MaxFileUploads:  makeGuestUploadCountLimit(2),
-			},
-			entriesInStore: []picoshare.UploadEntry{
-				{
-					UploadMetadata: picoshare.UploadMetadata{
-						ID:       picoshare.EntryID("dummy-entry1"),
-						Filename: picoshare.Filename("existing-1.txt"),
-						Uploaded: mustParseTime("2024-02-01T00:00:00Z"),
-						GuestLink: picoshare.GuestLink{
-							ID: picoshare.GuestLinkID("abcdefgh23456789"),
-						},
-						Expires: picoshare.NeverExpire,
-					},
-				},
-				{
-					UploadMetadata: picoshare.UploadMetadata{
-						ID:       picoshare.EntryID("dummy-entry2"),
-						Filename: picoshare.Filename("existing-2.txt"),
-						Uploaded: mustParseTime("2024-02-02T00:00:00Z"),
-						GuestLink: picoshare.GuestLink{
-							ID: picoshare.GuestLinkID("abcdefgh23456789"),
-						},
-						Expires: picoshare.NeverExpire,
-					},
-				},
-			},
-			expectedEntryCount: 2,
-			expectedStatus:     http.StatusUnauthorized,
-		},
-	} {
-		t.Run(tt.description, func(t *testing.T) {
-			dataStore := test_sqlite.New()
-			if err := dataStore.InsertGuestLink(tt.guestLinkInStore); err != nil {
-				t.Fatalf("failed to insert dummy guest link: %v", err)
-			}
-			for _, entry := range tt.entriesInStore {
-				data := "existing file contents"
-				entry.UploadMetadata.Size = mustParseFileSize(len(data))
-				if err := dataStore.InsertEntry(strings.NewReader(data), entry.UploadMetadata); err != nil {
-					t.Fatalf("failed to insert dummy entry: %v", err)
-				}
-			}
-
-			s := handlers.New(authenticator, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
-
-			formData, contentType := createMultipartFormBody("new-file.txt", "", strings.NewReader("new file contents"))
-			req, err := http.NewRequest("POST", "/api/guest/abcdefgh23456789?expiration=2030-01-01T00:00:00Z", formData)
-			if err != nil {
-				t.Fatal(err)
-			}
-			req.Header.Add("Content-Type", contentType)
-			req.Header.Add("Accept", "application/json")
-
-			rec := httptest.NewRecorder()
-			s.Router().ServeHTTP(rec, req)
-			res := rec.Result()
-
-			if got, want := res.StatusCode, tt.expectedStatus; got != want {
-				t.Fatalf("status=%d, want=%d", got, want)
-			}
-
-			entries, err := dataStore.GetEntriesMetadata()
-			if err != nil {
-				t.Fatalf("failed to list entries metadata: %v", err)
-			}
-
-			if got, want := len(entries), tt.expectedEntryCount; got != want {
-				t.Fatalf("entry count=%d, want=%d", got, want)
 			}
 		})
 	}

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -599,10 +599,14 @@ func TestGuestUpload(t *testing.T) {
 				t.Fatalf("failed to list entries metadata: %v", err)
 			}
 
-			expectedEntryCount := len(tt.entriesInStore)
-			if tt.status == http.StatusOK {
-				expectedEntryCount++
-			}
+			// On success, we expect the request to add a single entry to the store.
+			// On failure, we expect no new entries in the store.
+			expectedEntryCount := func() int {
+				if tt.status == http.StatusOK {
+					return len(tt.entriesInStore) + 1
+				}
+				return len(tt.entriesInStore)
+			}()
 			if got, want := len(entries), expectedEntryCount; got != want {
 				t.Fatalf("entry count=%d, want=%d", got, want)
 			}

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -725,6 +725,122 @@ func TestGuestUploadAcceptHeader(t *testing.T) {
 	}
 }
 
+func TestGuestUploadRejectsInactiveGuestLinksWithoutPersisting(t *testing.T) {
+	authenticator, err := shared_secret.New("dummypass")
+	if err != nil {
+		t.Fatalf("failed to create shared secret: %v", err)
+	}
+
+	for _, tt := range []struct {
+		description        string
+		guestLinkInStore   picoshare.GuestLink
+		entriesInStore     []picoshare.UploadEntry
+		expectedEntryCount int
+		expectedStatus     int
+	}{
+		{
+			description: "disabled guest link",
+			guestLinkInStore: picoshare.GuestLink{
+				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
+				Created:         mustParseTime("2024-01-01T00:00:00Z"),
+				UrlExpires:      mustParseExpirationTime("2030-01-02T03:04:25Z"),
+				MaxFileLifetime: picoshare.FileLifetimeInfinite,
+				IsDisabled:      true,
+			},
+			expectedEntryCount: 0,
+			expectedStatus:     http.StatusUnauthorized,
+		},
+		{
+			description: "expired guest link",
+			guestLinkInStore: picoshare.GuestLink{
+				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
+				Created:         mustParseTime("2022-02-21T00:00:00Z"),
+				UrlExpires:      mustParseExpirationTime("2022-02-22T03:04:25Z"),
+				MaxFileLifetime: picoshare.FileLifetimeInfinite,
+			},
+			expectedEntryCount: 0,
+			expectedStatus:     http.StatusUnauthorized,
+		},
+		{
+			description: "upload-count limit reached",
+			guestLinkInStore: picoshare.GuestLink{
+				ID:              picoshare.GuestLinkID("abcdefgh23456789"),
+				Created:         mustParseTime("2024-01-01T00:00:00Z"),
+				UrlExpires:      mustParseExpirationTime("2030-01-02T03:04:25Z"),
+				MaxFileLifetime: picoshare.FileLifetimeInfinite,
+				MaxFileUploads:  makeGuestUploadCountLimit(2),
+			},
+			entriesInStore: []picoshare.UploadEntry{
+				{
+					UploadMetadata: picoshare.UploadMetadata{
+						ID:       picoshare.EntryID("dummy-entry1"),
+						Filename: picoshare.Filename("existing-1.txt"),
+						Uploaded: mustParseTime("2024-02-01T00:00:00Z"),
+						GuestLink: picoshare.GuestLink{
+							ID: picoshare.GuestLinkID("abcdefgh23456789"),
+						},
+						Expires: picoshare.NeverExpire,
+					},
+				},
+				{
+					UploadMetadata: picoshare.UploadMetadata{
+						ID:       picoshare.EntryID("dummy-entry2"),
+						Filename: picoshare.Filename("existing-2.txt"),
+						Uploaded: mustParseTime("2024-02-02T00:00:00Z"),
+						GuestLink: picoshare.GuestLink{
+							ID: picoshare.GuestLinkID("abcdefgh23456789"),
+						},
+						Expires: picoshare.NeverExpire,
+					},
+				},
+			},
+			expectedEntryCount: 2,
+			expectedStatus:     http.StatusUnauthorized,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			dataStore := test_sqlite.New()
+			if err := dataStore.InsertGuestLink(tt.guestLinkInStore); err != nil {
+				t.Fatalf("failed to insert dummy guest link: %v", err)
+			}
+			for _, entry := range tt.entriesInStore {
+				data := "existing file contents"
+				entry.UploadMetadata.Size = mustParseFileSize(len(data))
+				if err := dataStore.InsertEntry(strings.NewReader(data), entry.UploadMetadata); err != nil {
+					t.Fatalf("failed to insert dummy entry: %v", err)
+				}
+			}
+
+			s := handlers.New(authenticator, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
+
+			formData, contentType := createMultipartFormBody("new-file.txt", "", strings.NewReader("new file contents"))
+			req, err := http.NewRequest("POST", "/api/guest/abcdefgh23456789?expiration=2030-01-01T00:00:00Z", formData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Add("Content-Type", contentType)
+			req.Header.Add("Accept", "application/json")
+
+			rec := httptest.NewRecorder()
+			s.Router().ServeHTTP(rec, req)
+			res := rec.Result()
+
+			if got, want := res.StatusCode, tt.expectedStatus; got != want {
+				t.Fatalf("status=%d, want=%d", got, want)
+			}
+
+			entries, err := dataStore.GetEntriesMetadata()
+			if err != nil {
+				t.Fatalf("failed to list entries metadata: %v", err)
+			}
+
+			if got, want := len(entries), tt.expectedEntryCount; got != want {
+				t.Fatalf("entry count=%d, want=%d", got, want)
+			}
+		})
+	}
+}
+
 func createMultipartFormBody(filename, note string, r io.Reader) (io.Reader, string) {
 	var b bytes.Buffer
 	bw := bufio.NewWriter(&b)


### PR DESCRIPTION
## Summary

This PR fixes a guest upload authorization bug in PicoShare.

`POST /api/guest/{guestLinkID}` now returns immediately after rejecting an inactive guest link. Before this change, expired, disabled, or upload-limit-exhausted guest links could still persist uploaded files after a `401` response.

## Validation

Added a regression test:

- `TestGuestUploadRejectsInactiveGuestLinksWithoutPersisting`

This verifies that disabled, expired, and upload-count-exhausted guest links return `401` without creating a new entry.
