### PR TITLE
Add Friendly-Links functionality 

### DIFF
--- a/e2e/upload.spec.ts
+++ b/e2e/upload.spec.ts
@@ -42,6 +42,34 @@ test("uploads a file without specifying any parameters", async ({
   await expect(matchingRow.getByRole("cell").nth(noteColumn)).toBeEmpty();
 });
 
+test("uploads a file with a friendly name", async ({ page }) => {
+  await login(page);
+
+  await page.locator("#friendly-name").fill("friendly-filename.txt");
+
+  await page.locator(".file-input").setInputFiles([
+    {
+      name: "upload-with-friendly-name-original.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("This upload uses a friendly name"),
+    },
+  ]);
+
+  await expect(page.locator("#upload-result .message-body")).toHaveText(
+    "Upload complete!"
+  );
+  await expect(page.locator("#upload-result upload-links")).toHaveAttribute(
+    "filename",
+    "friendly-filename.txt"
+  );
+
+  await page.getByRole("menuitem", { name: "Files" }).click();
+  const matchingRow = await page
+    .getByRole("row")
+    .filter({ hasText: "friendly-filename.txt" });
+  await expect(matchingRow).toBeVisible();
+});
+
 test("uploads a file with a custom expiration time", async ({ page }) => {
   await login(page);
 

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/mtlynch/picoshare/handlers/parse"
 	"github.com/mtlynch/picoshare/picoshare"
 	"github.com/mtlynch/picoshare/store"
 )
@@ -25,40 +26,70 @@ func (s Server) entryGet() http.HandlerFunc {
 			return
 		}
 
-		entry, err := s.getDB(r).GetEntryMetadata(id)
-		if _, ok := errors.AsType[store.EntryNotFoundError](err); ok {
-			http.Error(w, "entry not found", http.StatusNotFound)
+		s.serveEntry(w, r, id)
+	}
+}
+
+func (s Server) friendlyLinkGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name, err := parse.FriendlyName(mux.Vars(r)["friendlyName"])
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid friendly name: %v", err), http.StatusBadRequest)
+			return
+		}
+		fl, err := s.getDB(r).GetFriendlyLink(name)
+		if _, ok := errors.AsType[store.FriendlyLinkNotFoundError](err); ok {
+			http.Error(w, "friendly link not found", http.StatusNotFound)
 			return
 		} else if err != nil {
-			log.Printf("error retrieving entry with id %v: %v", id, err)
-			http.Error(w, "failed to retrieve entry", http.StatusInternalServerError)
+			log.Printf("error retrieving friendly link %s: %v", name, err)
+			http.Error(w, "failed to retrieve friendly link", http.StatusInternalServerError)
 			return
 		}
 
-		if entry.Filename != "" {
-			w.Header().Set("Content-Disposition", fmt.Sprintf(`filename="%s"`, entry.Filename))
-		}
-
-		contentType := entry.ContentType
-		if contentType == "" || contentType == "application/octet-stream" {
-			if inferred, err := inferContentTypeFromFilename(entry.Filename); err == nil {
-				contentType = inferred
-			}
-		}
-		w.Header().Set("Content-Type", contentType.String())
-
-		entryFile, err := s.getDB(r).ReadEntryFile(id)
-		if err != nil {
-			log.Printf("error retrieving entry data with id %v: %v", id, err)
-			http.Error(w, "failed to retrieve entry", http.StatusInternalServerError)
+		if fl.IsDisabled {
+			http.Error(w, "friendly link inactive", http.StatusGone)
 			return
 		}
 
-		http.ServeContent(w, r, entry.Filename.String(), entry.Uploaded, entryFile)
+		s.serveEntry(w, r, fl.EntryID)
+	}
+}
 
-		if err := recordDownload(s.getDB(r), entry.ID, s.clock.Now(), r.RemoteAddr, r.Header.Get("User-Agent")); err != nil {
-			log.Printf("failed to record download of file %s: %v", id.String(), err)
+func (s Server) serveEntry(w http.ResponseWriter, r *http.Request, id picoshare.EntryID) {
+	entry, err := s.getDB(r).GetEntryMetadata(id)
+	if _, ok := errors.AsType[store.EntryNotFoundError](err); ok {
+		http.Error(w, "entry not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		log.Printf("error retrieving entry with id %v: %v", id, err)
+		http.Error(w, "failed to retrieve entry", http.StatusInternalServerError)
+		return
+	}
+
+	if entry.Filename != "" {
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`filename="%s"`, entry.Filename))
+	}
+
+	contentType := entry.ContentType
+	if contentType == "" || contentType == "application/octet-stream" {
+		if inferred, err := inferContentTypeFromFilename(entry.Filename); err == nil {
+			contentType = inferred
 		}
+	}
+	w.Header().Set("Content-Type", contentType.String())
+
+	entryFile, err := s.getDB(r).ReadEntryFile(id)
+	if err != nil {
+		log.Printf("error retrieving entry data with id %v: %v", id, err)
+		http.Error(w, "failed to retrieve entry", http.StatusInternalServerError)
+		return
+	}
+
+	http.ServeContent(w, r, entry.Filename.String(), entry.Uploaded, entryFile)
+
+	if err := recordDownload(s.getDB(r), entry.ID, s.clock.Now(), r.RemoteAddr, r.Header.Get("User-Agent")); err != nil {
+		log.Printf("failed to record download of file %s: %v", id.String(), err)
 	}
 }
 

--- a/handlers/friendly_links.go
+++ b/handlers/friendly_links.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/mtlynch/picoshare/handlers/parse"
+)
+
+func (s Server) friendlyLinksDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name, err := parse.FriendlyName(mux.Vars(r)["friendlyName"])
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid friendly name: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if err := s.getDB(r).DeleteFriendlyLink(name); err != nil {
+			log.Printf("failed to delete friendly link: %v", err)
+			http.Error(w, fmt.Sprintf("Failed to delete friendly link: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func (s *Server) friendlyLinksEnableDisable() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name, err := parse.FriendlyName(mux.Vars(r)["friendlyName"])
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid friendly name: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		fl, err := s.getDB(r).GetFriendlyLink(name)
+		if err != nil {
+			log.Printf("failed to get friendly link %s: %v", name, err)
+			http.Error(w, fmt.Sprintf("Friendly link with name %s not found: %v", name, err), http.StatusNotFound)
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/enable") {
+			fl.IsDisabled = false
+		} else {
+			fl.IsDisabled = true
+		}
+
+		if err := s.getDB(r).UpdateFriendlyLink(fl); err != nil {
+			log.Printf("failed to change friendly link enabled state: %v", err)
+			http.Error(w, fmt.Sprintf("Failed to change friendly link enabled state: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/handlers/friendly_links_test.go
+++ b/handlers/friendly_links_test.go
@@ -1,0 +1,291 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mtlynch/picoshare/handlers"
+	"github.com/mtlynch/picoshare/picoshare"
+	"github.com/mtlynch/picoshare/store/test_sqlite"
+)
+
+func TestFriendlyLinks(t *testing.T) {
+	db := test_sqlite.New()
+	clock := mockClock{t: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}
+	s := handlers.New(mockAuthenticator{}, &db, nil, nil, clock)
+
+	// 1. Upload a file with a friendly name
+	filename := "test.txt"
+	contents := "hello friendly world"
+	friendlyName := "my-friendly-link"
+	
+	id1 := uploadWithFriendlyName(t, s, filename, contents, friendlyName, false)
+
+	// 2. Retrieve the file via friendly name
+	checkFriendlyLink(t, s, friendlyName, contents)
+
+	// 3. Upload another file with the same friendly name, NO delete old
+	contents2 := "updated content"
+	id2 := uploadWithFriendlyName(t, s, filename, contents2, friendlyName, false)
+
+	if id1 == id2 {
+		t.Errorf("expected different IDs for different uploads, got %s", id1)
+	}
+
+	// Verify it now serves the new content
+	checkFriendlyLink(t, s, friendlyName, contents2)
+
+	// Verify old file still exists
+	if _, err := db.GetEntryMetadata(id1); err != nil {
+		t.Errorf("expected old file %s to still exist, but got error: %v", id1, err)
+	}
+
+	// 4. Upload another file with same friendly name, WITH delete old
+	contents3 := "final content"
+	_ = uploadWithFriendlyName(t, s, filename, contents3, friendlyName, true)
+
+	// Verify it now serves the new content
+	checkFriendlyLink(t, s, friendlyName, contents3)
+
+	// Verify old file (id2) is deleted
+	if _, err := db.GetEntryMetadata(id2); err == nil {
+		t.Errorf("expected old file %s to be deleted, but it still exists", id2)
+	}
+
+	// Verify id1 still exists (because only the immediately previous one pointed to by the friendly link is deleted)
+	if _, err := db.GetEntryMetadata(id1); err != nil {
+		t.Errorf("expected file %s to still exist, but got error: %v", id1, err)
+	}
+
+	// 5. Verify disabled friendly link
+	fl, err := db.GetFriendlyLink(picoshare.FriendlyName(friendlyName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fl.IsDisabled = true
+	if err := db.UpdateFriendlyLink(fl); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/n/%s", friendlyName), nil)
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusGone {
+		t.Errorf("expected status %d for disabled friendly link, got %d", http.StatusGone, rr.Code)
+	}
+
+	// 6. Guest upload with friendly name
+	guestLinkID := picoshare.GuestLinkID("guestinkidsixtee")
+	gl := picoshare.GuestLink{
+		ID:              guestLinkID,
+		MaxFileLifetime: picoshare.FileLifetimeInfinite,
+		Created:         clock.t,
+		UrlExpires:      picoshare.NeverExpire,
+	}
+	if err := db.InsertGuestLink(gl); err != nil {
+		t.Fatal(err)
+	}
+
+	guestFriendlyName := "guest-friendly"
+	guestContents := "guest content"
+	_ = uploadGuestWithFriendlyName(t, s, "guest.txt", guestContents, guestLinkID, guestFriendlyName)
+
+	checkFriendlyLink(t, s, guestFriendlyName, guestContents)
+}
+
+func TestFriendlyLinksCLI(t *testing.T) {
+	db := test_sqlite.New()
+	clock := mockClock{t: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}
+	s := handlers.New(mockAuthenticator{}, &db, nil, nil, clock)
+
+	guestLinkID := picoshare.GuestLinkID("guestinkidsixtee")
+	gl := picoshare.GuestLink{
+		ID:              guestLinkID,
+		MaxFileLifetime: picoshare.FileLifetimeInfinite,
+		Created:         clock.t,
+		UrlExpires:      picoshare.NeverExpire,
+	}
+	if err := db.InsertGuestLink(gl); err != nil {
+		t.Fatal(err)
+	}
+
+	filename := "test.txt"
+	contents := "hello cli world"
+	friendlyName := "cli-friendly"
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(part, bytes.NewBufferString(contents)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteField("friendly_name", friendlyName); err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	// Simulating CLI (no Accept: application/json)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/guest/%s?expiration=2040-01-01T00:00:00Z", guestLinkID), body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("upload failed with status %d: %s", rr.Code, rr.Body.String())
+	}
+
+	expectedURL := fmt.Sprintf("http://example.com/n/%s\r\n", friendlyName)
+	if rr.Body.String() != expectedURL {
+		t.Errorf("expected URL %q, got %q", expectedURL, rr.Body.String())
+	}
+}
+
+func TestFriendlyLinksQueryParams(t *testing.T) {
+	db := test_sqlite.New()
+	clock := mockClock{t: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}
+	s := handlers.New(mockAuthenticator{}, &db, nil, nil, clock)
+
+	guestLinkID := picoshare.GuestLinkID("guestinkidsixtee")
+	gl := picoshare.GuestLink{
+		ID:              guestLinkID,
+		MaxFileLifetime: picoshare.FileLifetimeInfinite,
+		Created:         clock.t,
+		UrlExpires:      picoshare.NeverExpire,
+	}
+	if err := db.InsertGuestLink(gl); err != nil {
+		t.Fatal(err)
+	}
+
+	friendlyName := "query-friendly"
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(part, bytes.NewBufferString("query params test")); err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	// Parameters in query string
+	url := fmt.Sprintf("/api/guest/%s?expiration=2040-01-01T00:00:00Z&friendly_name=%s&delete_old=true", guestLinkID, friendlyName)
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("upload failed with status %d: %s", rr.Code, rr.Body.String())
+	}
+
+	checkFriendlyLink(t, s, friendlyName, "query params test")
+}
+
+func uploadGuestWithFriendlyName(t *testing.T, s handlers.Server, filename, contents string, guestLinkID picoshare.GuestLinkID, friendlyName string) picoshare.EntryID {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(part, bytes.NewBufferString(contents)); err != nil {
+		t.Fatal(err)
+	}
+	if friendlyName != "" {
+		if err := writer.WriteField("friendly_name", friendlyName); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/guest/%s?expiration=2040-01-01T00:00:00Z", guestLinkID), body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("guest upload failed with status %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	return picoshare.EntryID(resp.ID)
+}
+
+func uploadWithFriendlyName(t *testing.T, s handlers.Server, filename, contents, friendlyName string, deleteOld bool) picoshare.EntryID {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(part, bytes.NewBufferString(contents)); err != nil {
+		t.Fatal(err)
+	}
+	if friendlyName != "" {
+		if err := writer.WriteField("friendly_name", friendlyName); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if deleteOld {
+		if err := writer.WriteField("delete_old", "true"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/entry?expiration=2040-01-01T00:00:00Z", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("upload failed with status %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+
+	return picoshare.EntryID(resp.ID)
+}
+
+func checkFriendlyLink(t *testing.T, s handlers.Server, friendlyName, expectedContents string) {
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/n/%s", friendlyName), nil)
+	rr := httptest.NewRecorder()
+	s.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("failed to retrieve friendly link %s: status %d", friendlyName, rr.Code)
+	}
+
+	if rr.Body.String() != expectedContents {
+		t.Errorf("expected contents %q, got %q", expectedContents, rr.Body.String())
+	}
+}

--- a/handlers/friendly_links_test.go
+++ b/handlers/friendly_links_test.go
@@ -25,7 +25,7 @@ func TestFriendlyLinks(t *testing.T) {
 	filename := "test.txt"
 	contents := "hello friendly world"
 	friendlyName := "my-friendly-link"
-	
+
 	id1 := uploadWithFriendlyName(t, s, filename, contents, friendlyName, false)
 
 	// 2. Retrieve the file via friendly name

--- a/handlers/parse/friendly_name.go
+++ b/handlers/parse/friendly_name.go
@@ -1,0 +1,29 @@
+package parse
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/mtlynch/picoshare/picoshare"
+)
+
+const MaxFriendlyNameBytes = 200
+
+var ErrFriendlyNameEmpty = errors.New("friendly name must be non-empty")
+var ErrFriendlyNameTooLong = errors.New("friendly name too long")
+var ErrFriendlyNameInvalidCharacters = errors.New("friendly name contains invalid characters")
+
+var friendlyNameRegex = regexp.MustCompile(`^[a-zA-Z0-9\._-]+$`)
+
+func FriendlyName(s string) (picoshare.FriendlyName, error) {
+	if s == "" {
+		return picoshare.FriendlyName(""), ErrFriendlyNameEmpty
+	}
+	if len(s) > MaxFriendlyNameBytes {
+		return picoshare.FriendlyName(""), ErrFriendlyNameTooLong
+	}
+	if !friendlyNameRegex.MatchString(s) {
+		return picoshare.FriendlyName(""), ErrFriendlyNameInvalidCharacters
+	}
+	return picoshare.FriendlyName(s), nil
+}

--- a/handlers/routes.go
+++ b/handlers/routes.go
@@ -16,6 +16,9 @@ func (s *Server) routes() {
 	authenticatedApis.HandleFunc("/guest-links/{id}", s.guestLinksDelete()).Methods(http.MethodDelete)
 	authenticatedApis.HandleFunc("/guest-links/{id}/enable", s.guestLinksEnableDisable()).Methods(http.MethodPut)
 	authenticatedApis.HandleFunc("/guest-links/{id}/disable", s.guestLinksEnableDisable()).Methods(http.MethodPut)
+	authenticatedApis.HandleFunc("/friendly-links/{friendlyName}", s.friendlyLinksDelete()).Methods(http.MethodDelete)
+	authenticatedApis.HandleFunc("/friendly-links/{friendlyName}/enable", s.friendlyLinksEnableDisable()).Methods(http.MethodPut)
+	authenticatedApis.HandleFunc("/friendly-links/{friendlyName}/disable", s.friendlyLinksEnableDisable()).Methods(http.MethodPut)
 	authenticatedApis.HandleFunc("/settings", s.settingsPut()).Methods(http.MethodPut)
 
 	publicApis := s.router.PathPrefix("/api").Subrouter()
@@ -53,6 +56,7 @@ func (s *Server) routes() {
 	authenticatedViews.HandleFunc("/files/{id}/confirm-delete", s.fileConfirmDeleteGet()).Methods(http.MethodGet)
 	authenticatedViews.HandleFunc("/guest-links", s.guestLinkIndexGet()).Methods(http.MethodGet)
 	authenticatedViews.HandleFunc("/guest-links/new", s.guestLinksNewGet()).Methods(http.MethodGet)
+	authenticatedViews.HandleFunc("/friendly-links", s.friendlyLinkIndexGet()).Methods(http.MethodGet)
 	authenticatedViews.HandleFunc("/settings", s.settingsGet()).Methods(http.MethodGet)
 
 	views := s.router.PathPrefix("/").Subrouter()
@@ -74,6 +78,7 @@ func (s *Server) routes() {
 	})
 	downloadViews.PathPrefix("/-{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
 	downloadViews.PathPrefix("/-{id}/{filename}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)
+	downloadViews.PathPrefix("/n/{friendlyName}").HandlerFunc(s.friendlyLinkGet()).Methods(http.MethodGet)
 	// Legacy routes for entries. We stopped using them because the ! has
 	// unintended side effects within the bash shell.
 	downloadViews.PathPrefix("/!{id}").HandlerFunc(s.entryGet()).Methods(http.MethodGet)

--- a/handlers/static/js/controllers/files.js
+++ b/handlers/static/js/controllers/files.js
@@ -44,11 +44,28 @@ function uploadFormData(url, formData, progressFn) {
     });
 }
 
-export async function uploadFile(file, expirationTime, note, progressFn) {
+export async function uploadFile(
+  file,
+  expirationTime,
+  filename,
+  note,
+  friendlyLinkName,
+  deleteOld,
+  progressFn
+) {
   const formData = new FormData();
   formData.append("file", file);
+  if (filename) {
+    formData.append("filename", filename);
+  }
   if (note) {
     formData.append("note", note);
+  }
+  if (friendlyLinkName) {
+    formData.append("friendly_name", friendlyLinkName);
+  }
+  if (deleteOld) {
+    formData.append("delete_old", "true");
   }
   return uploadFormData(
     `/api/entry?expiration=${encodeURIComponent(expirationTime)}`,
@@ -61,10 +78,22 @@ export async function guestUploadFile(
   file,
   guestLinkID,
   expirationTime,
+  filename,
+  friendlyLinkName,
+  deleteOld,
   progressFn
 ) {
   const formData = new FormData();
   formData.append("file", file);
+  if (filename) {
+    formData.append("filename", filename);
+  }
+  if (friendlyLinkName) {
+    formData.append("friendly_name", friendlyLinkName);
+  }
+  if (deleteOld) {
+    formData.append("delete_old", "true");
+  }
   return uploadFormData(
     `/api/guest/${guestLinkID}?expiration=${encodeURIComponent(
       expirationTime

--- a/handlers/static/js/controllers/friendlyLinks.js
+++ b/handlers/static/js/controllers/friendlyLinks.js
@@ -25,10 +25,13 @@ export async function friendlyLinkDelete(friendlyName) {
 }
 
 export async function friendlyLinkEnable(friendlyName) {
-  return fetch(`/api/friendly-links/${encodeURIComponent(friendlyName)}/enable`, {
-    method: "PUT",
-    credentials: "include",
-  })
+  return fetch(
+    `/api/friendly-links/${encodeURIComponent(friendlyName)}/enable`,
+    {
+      method: "PUT",
+      credentials: "include",
+    }
+  )
     .then((response) => {
       if (!response.ok) {
         return response.text().then((error) => {
@@ -49,10 +52,13 @@ export async function friendlyLinkEnable(friendlyName) {
 }
 
 export async function friendlyLinkDisable(friendlyName) {
-  return fetch(`/api/friendly-links/${encodeURIComponent(friendlyName)}/disable`, {
-    method: "PUT",
-    credentials: "include",
-  })
+  return fetch(
+    `/api/friendly-links/${encodeURIComponent(friendlyName)}/disable`,
+    {
+      method: "PUT",
+      credentials: "include",
+    }
+  )
     .then((response) => {
       if (!response.ok) {
         return response.text().then((error) => {

--- a/handlers/static/js/controllers/friendlyLinks.js
+++ b/handlers/static/js/controllers/friendlyLinks.js
@@ -1,0 +1,73 @@
+"use strict";
+
+export async function friendlyLinkDelete(friendlyName) {
+  return fetch(`/api/friendly-links/${encodeURIComponent(friendlyName)}`, {
+    method: "DELETE",
+    credentials: "include",
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.text().then((error) => {
+          return Promise.reject(error);
+        });
+      }
+      return Promise.resolve();
+    })
+    .catch((error) => {
+      if (error.message) {
+        return Promise.reject(
+          "Failed to communicate with server" +
+            (error.message ? `: ${error.message}` : ".")
+        );
+      }
+      return Promise.reject(error);
+    });
+}
+
+export async function friendlyLinkEnable(friendlyName) {
+  return fetch(`/api/friendly-links/${encodeURIComponent(friendlyName)}/enable`, {
+    method: "PUT",
+    credentials: "include",
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.text().then((error) => {
+          return Promise.reject(error);
+        });
+      }
+      return Promise.resolve();
+    })
+    .catch((error) => {
+      if (error.message) {
+        return Promise.reject(
+          "Failed to communicate with server" +
+            (error.message ? `: ${error.message}` : ".")
+        );
+      }
+      return Promise.reject(error);
+    });
+}
+
+export async function friendlyLinkDisable(friendlyName) {
+  return fetch(`/api/friendly-links/${encodeURIComponent(friendlyName)}/disable`, {
+    method: "PUT",
+    credentials: "include",
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.text().then((error) => {
+          return Promise.reject(error);
+        });
+      }
+      return Promise.resolve();
+    })
+    .catch((error) => {
+      if (error.message) {
+        return Promise.reject(
+          "Failed to communicate with server" +
+            (error.message ? `: ${error.message}` : ".")
+        );
+      }
+      return Promise.reject(error);
+    });
+}

--- a/handlers/store.go
+++ b/handlers/store.go
@@ -19,6 +19,11 @@ type Store interface {
 	DeleteGuestLink(picoshare.GuestLinkID) error
 	DisableGuestLink(picoshare.GuestLinkID) error
 	EnableGuestLink(picoshare.GuestLinkID) error
+	GetFriendlyLink(friendlyName picoshare.FriendlyName) (picoshare.FriendlyLink, error)
+	GetFriendlyLinks() ([]picoshare.FriendlyLink, error)
+	InsertFriendlyLink(picoshare.FriendlyLink) error
+	UpdateFriendlyLink(picoshare.FriendlyLink) error
+	DeleteFriendlyLink(friendlyName picoshare.FriendlyName) error
 	InsertEntryDownload(picoshare.EntryID, picoshare.DownloadRecord) error
 	GetEntryDownloads(id picoshare.EntryID) ([]picoshare.DownloadRecord, error)
 	ReadSettings() (picoshare.Settings, error)

--- a/handlers/templates/pages/friendly-link-index.html
+++ b/handlers/templates/pages/friendly-link-index.html
@@ -158,12 +158,11 @@
   <h1 class="h1">Friendly Links</h1>
 
   <div class="alert alert-primary" role="alert">
-    <p>
-      Friendly links provide human-readable URLs for your files.
-    </p>
+    <p>Friendly links provide human-readable URLs for your files.</p>
 
     <p>
-      You can assign a friendly name to a file during upload, and it will be accessible at <code>/n/friendly-name</code>.
+      You can assign a friendly name to a file during upload, and it will be
+      accessible at <code>/n/friendly-name</code>.
     </p>
   </div>
 

--- a/handlers/templates/pages/friendly-link-index.html
+++ b/handlers/templates/pages/friendly-link-index.html
@@ -1,0 +1,245 @@
+{{ define "style-tags" }}
+  <style nonce="{{ .CspNonce }}">
+    .deleted-entry {
+      text-decoration: line-through;
+      color: darkgray;
+      visibility: collapse;
+      opacity: 0;
+    }
+
+    .table {
+      & tr {
+        transition: all 1000ms ease-out;
+
+        /* Show aria-label in a tooltip over the button. */
+        button[aria-label]:hover::after {
+          content: attr(aria-label);
+          position: absolute;
+          background: #333;
+          color: white;
+          padding: 4px 8px;
+          border-radius: 4px;
+          font-size: 14px;
+          margin-top: -5rem;
+          white-space: nowrap;
+        }
+
+        button {
+          position: relative;
+        }
+      }
+
+      & .inactive {
+        background-color: #d9d9d9;
+      }
+
+      & .inactive [aria-label="Copy"] {
+        display: none;
+      }
+    }
+
+    #error {
+      max-width: 60ch;
+    }
+  </style>
+{{ end }}
+
+{{ define "script-tags" }}
+  <script type="module" nonce="{{ .CspNonce }}">
+    import {
+      friendlyLinkDelete,
+      friendlyLinkEnable,
+      friendlyLinkDisable,
+    } from "/js/controllers/friendlyLinks.js";
+    import { showElement, hideElement } from "/js/lib/bulma.js";
+    import { copyToClipboard } from "/js/lib/clipboard.js";
+
+    const errorContainer = document.getElementById("error");
+
+    function makeFriendlyLink(friendlyName) {
+      return `${window.location.origin}/n/${friendlyName}`;
+    }
+
+    document.querySelectorAll('[aria-label="Delete"]').forEach((deleteBtn) => {
+      deleteBtn.addEventListener("click", () => {
+        const name = deleteBtn.getAttribute("pico-friendly-name");
+        friendlyLinkDelete(name)
+          .then(() => {
+            let currentEl = deleteBtn.parentElement;
+            while (currentEl && currentEl.nodeName !== "TR") {
+              currentEl = currentEl.parentElement;
+            }
+            if (!currentEl) {
+              return;
+            }
+
+            currentEl.classList.add("deleted-entry");
+          })
+          .catch((error) => {
+            document.getElementById("error-message").innerText = error;
+            showElement(errorContainer);
+          });
+      });
+    });
+
+    document
+      .querySelector("#error .btn-close")
+      .addEventListener("click", () => {
+        hideElement(errorContainer);
+      });
+
+    document.querySelectorAll('[aria-label="Copy"]').forEach((copyBtn) => {
+      copyBtn.addEventListener("click", () => {
+        const friendlyName = copyBtn.getAttribute("pico-friendly-name");
+        const friendlyLink = makeFriendlyLink(friendlyName);
+
+        copyToClipboard(friendlyLink)
+          .then(() =>
+            document
+              .querySelector("snackbar-notifications")
+              .addInfoMessage("Copied link")
+          )
+          .catch((error) => {
+            document.getElementById("error-message").innerText = error;
+            showElement(errorContainer);
+          });
+      });
+    });
+
+    // Switch the state of the friendly link.
+    document
+      .querySelectorAll('[aria-label="Enable"], [aria-label="Disable"]')
+      .forEach((toggleBtn) => {
+        toggleBtn.addEventListener("click", () => {
+          const currentState = toggleBtn.getAttribute("aria-label");
+          const name = toggleBtn.getAttribute("pico-friendly-name");
+
+          let apiCall = undefined;
+          let snackBarMessage = undefined;
+          let newAriaLabel = undefined;
+
+          if (toggleBtn.getAttribute("aria-label") === "Enable") {
+            apiCall = friendlyLinkEnable;
+            snackBarMessage = "Friendly link reactivated";
+            newAriaLabel = "Disable";
+          } else {
+            apiCall = friendlyLinkDisable;
+            snackBarMessage = "Friendly link disabled";
+            newAriaLabel = "Enable";
+          }
+
+          apiCall(name)
+            .then(() => {
+              toggleBtn.setAttribute("aria-label", newAriaLabel);
+
+              // Toggle the friendly link's row active state in the table.
+              toggleBtn.closest("tr").classList.toggle("inactive");
+
+              // Switch the button color and icon.
+              toggleBtn.classList.toggle("btn-outline-info");
+              toggleBtn.classList.toggle("btn-outline-secondary");
+              toggleBtn.querySelector("i").classList.toggle("fa-ban");
+              toggleBtn.querySelector("i").classList.toggle("fa-square-check");
+
+              document
+                .querySelector("snackbar-notifications")
+                .addInfoMessage(snackBarMessage);
+            })
+            .catch((error) => {
+              document.getElementById("error-message").innerText = error;
+              showElement(errorContainer);
+            });
+        });
+      });
+  </script>
+{{ end }}
+
+{{ define "content" }}
+  <h1 class="h1">Friendly Links</h1>
+
+  <div class="alert alert-primary" role="alert">
+    <p>
+      Friendly links provide human-readable URLs for your files.
+    </p>
+
+    <p>
+      You can assign a friendly name to a file during upload, and it will be accessible at <code>/n/friendly-name</code>.
+    </p>
+  </div>
+
+  <div class="table-responsive mt-4">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Friendly Name</th>
+          <th>Created</th>
+          <th>Expiration</th>
+          <th class="text-end">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .FriendlyLinks }}
+          <tr {{ if .IsDisabled }}class="inactive"{{ end }}>
+            <td class="align-middle">
+              <a href="/n/{{ .FriendlyName }}">
+                {{ .FriendlyName }}
+              </a>
+            </td>
+            <td class="align-middle">{{ formatDate .Created }}</td>
+            <td class="align-middle expiration">
+              {{ formatExpiration .UrlExpires }}
+            </td>
+            <td class="align-middle">
+              <div class="d-flex justify-content-end gap-2">
+                <button
+                  class="btn btn-outline-primary btn-sm"
+                  aria-label="Copy"
+                  pico-friendly-name="{{ .FriendlyName }}"
+                >
+                  <i class="fa-solid fa-copy"></i>
+                </button>
+                {{ if .IsDisabled }}
+                  <button
+                    class="btn btn-outline-info btn-sm"
+                    aria-label="Enable"
+                    pico-friendly-name="{{ .FriendlyName }}"
+                  >
+                    <i class="fa-solid fa-square-check" aria-hidden="true"></i>
+                  </button>
+                {{ else }}
+                  <button
+                    class="btn btn-outline-secondary btn-sm"
+                    aria-label="Disable"
+                    pico-friendly-name="{{ .FriendlyName }}"
+                  >
+                    <i class="fa-solid fa-ban" aria-hidden="true"></i>
+                  </button>
+                {{ end }}
+                <button
+                  class="btn btn-outline-danger btn-sm"
+                  aria-label="Delete"
+                  pico-friendly-name="{{ .FriendlyName }}"
+                >
+                  <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                </button>
+              </div>
+            </td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+
+  <div id="error" class="d-none my-3">
+    <div
+      class="alert alert-danger d-flex justify-content-between align-items-start"
+      role="alert"
+    >
+      <div>
+        <strong>Error</strong>
+        <div id="error-message" class="mt-1">Placeholder error.</div>
+      </div>
+      <button class="btn-close" type="button" aria-label="Close"></button>
+    </div>
+  </div>
+{{ end }}

--- a/handlers/templates/pages/upload.html
+++ b/handlers/templates/pages/upload.html
@@ -89,6 +89,9 @@
     const expirationContainer = document.querySelector(".expiration-container");
     const expirationSelect = document.getElementById("expiration-select");
     const expirationPicker = document.getElementById("expiration-picker");
+    const filenameInput = document.getElementById("custom-filename");
+    const friendlyLinkNameInput = document.getElementById("friendly-link-name");
+    const deleteOldInput = document.getElementById("delete-old");
     const noteInput = document.getElementById("note");
     const uploadAnotherBtn = document.getElementById("upload-another-btn");
 
@@ -112,8 +115,20 @@
       }
     }
 
+    function readFilename() {
+      return filenameInput?.value || null;
+    }
+
+    function readFriendlyLinkName() {
+      return friendlyLinkNameInput?.value || null;
+    }
+
+    function readDeleteOld() {
+      return deleteOldInput?.checked || false;
+    }
+
     function readNote() {
-      return noteInput.value || null;
+      return noteInput?.value || null;
     }
 
     function populateEditButton(entryId) {
@@ -159,8 +174,17 @@
       hideElement(uploadForm);
       showElement(progressBar);
 
+      const friendlyFilename = readFilename() ?? file.name;
       let uploader = () => {
-        return uploadFile(file, readExpiration(), readNote(), updateProgress);
+        return uploadFile(
+          file,
+          readExpiration(),
+          friendlyFilename,
+          readNote(),
+          readFriendlyLinkName(),
+          readDeleteOld(),
+          updateProgress
+        );
       };
       if (guestLinkMetadata) {
         uploader = () => {
@@ -168,6 +192,9 @@
             file,
             guestLinkMetadata.id,
             readExpiration(),
+            friendlyFilename,
+            readFriendlyLinkName(),
+            readDeleteOld(),
             updateProgress
           );
         };
@@ -180,7 +207,7 @@
 
           const uploadLinksEl = document.createElement("upload-links");
           uploadLinksEl.fileId = entryId;
-          uploadLinksEl.filename = file.name;
+          uploadLinksEl.filename = friendlyFilename;
           uploadLinksEl.addEventListener("link-copied", () => {
             document
               .querySelector("snackbar-notifications")
@@ -365,6 +392,44 @@
         <expiration-picker id="expiration-picker" class="d-none mt-3 d-block" />
       </div>
     {{ end }}
+
+      <div class="mb-4 field-max-width">
+        <label class="form-label">Filename <i>(optional)</i></label>
+        <input
+          id="custom-filename"
+          name="filename"
+          class="form-control"
+          type="text"
+          placeholder="my-file-name.txt"
+          maxlength="{{ .MaxFilenameLength }}"
+        />
+        <p class="form-text">If left blank, PicoShare uses the original filename.</p>
+      </div>
+
+      <div class="mb-4 field-max-width">
+        <label class="form-label">Friendly Link Name <i>(optional)</i></label>
+        <input
+          id="friendly-link-name"
+          name="friendly_link_name"
+          class="form-control"
+          type="text"
+          placeholder="latest-report"
+          maxlength="200"
+        />
+        <p class="form-text">If set, you can access the file at /n/friendly-link-name</p>
+      </div>
+
+      <div class="mb-4 field-max-width">
+        <label class="form-check-label">
+          <input
+            id="delete-old"
+            name="delete_old"
+            type="checkbox"
+            class="form-check-input"
+          />
+          Delete old file if friendly link name exists
+        </label>
+      </div>
 
     {{ if not .GuestLinkMetadata.ID }}
       <div class="mb-4 field-max-width">

--- a/handlers/templates/pages/upload.html
+++ b/handlers/templates/pages/upload.html
@@ -393,43 +393,48 @@
       </div>
     {{ end }}
 
-      <div class="mb-4 field-max-width">
-        <label class="form-label">Filename <i>(optional)</i></label>
-        <input
-          id="custom-filename"
-          name="filename"
-          class="form-control"
-          type="text"
-          placeholder="my-file-name.txt"
-          maxlength="{{ .MaxFilenameLength }}"
-        />
-        <p class="form-text">If left blank, PicoShare uses the original filename.</p>
-      </div>
 
-      <div class="mb-4 field-max-width">
-        <label class="form-label">Friendly Link Name <i>(optional)</i></label>
-        <input
-          id="friendly-link-name"
-          name="friendly_link_name"
-          class="form-control"
-          type="text"
-          placeholder="latest-report"
-          maxlength="200"
-        />
-        <p class="form-text">If set, you can access the file at /n/friendly-link-name</p>
-      </div>
+    <div class="mb-4 field-max-width">
+      <label class="form-label">Filename <i>(optional)</i></label>
+      <input
+        id="custom-filename"
+        name="filename"
+        class="form-control"
+        type="text"
+        placeholder="my-file-name.txt"
+        maxlength="{{ .MaxFilenameLength }}"
+      />
+      <p class="form-text">
+        If left blank, PicoShare uses the original filename.
+      </p>
+    </div>
 
-      <div class="mb-4 field-max-width">
-        <label class="form-check-label">
-          <input
-            id="delete-old"
-            name="delete_old"
-            type="checkbox"
-            class="form-check-input"
-          />
-          Delete old file if friendly link name exists
-        </label>
-      </div>
+    <div class="mb-4 field-max-width">
+      <label class="form-label">Friendly Link Name <i>(optional)</i></label>
+      <input
+        id="friendly-link-name"
+        name="friendly_link_name"
+        class="form-control"
+        type="text"
+        placeholder="latest-report"
+        maxlength="200"
+      />
+      <p class="form-text">
+        If set, you can access the file at /n/friendly-link-name
+      </p>
+    </div>
+
+    <div class="mb-4 field-max-width">
+      <label class="form-check-label">
+        <input
+          id="delete-old"
+          name="delete_old"
+          type="checkbox"
+          class="form-check-input"
+        />
+        Delete old file if friendly link name exists
+      </label>
+    </div>
 
     {{ if not .GuestLinkMetadata.ID }}
       <div class="mb-4 field-max-width">

--- a/handlers/templates/partials/navbar.html
+++ b/handlers/templates/partials/navbar.html
@@ -29,6 +29,11 @@
                 >Guest Links</a
               >
             </li>
+            <li class="nav-item">
+              <a class="nav-link" role="menuitem" href="/friendly-links"
+                >Friendly Links</a
+              >
+            </li>
           </ul>
         {{ end }}
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/mtlynch/picoshare/handlers/parse"
@@ -22,7 +23,8 @@ var entryIDCharacters = []rune("abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXY
 
 type (
 	EntryPostResponse struct {
-		ID string `json:"id"`
+		ID           string `json:"id"`
+		FriendlyName string `json:"friendly_name,omitempty"`
 	}
 
 	dbError struct {
@@ -50,7 +52,7 @@ func (s Server) entryPost() http.HandlerFunc {
 		// We're intentionally not limiting the size of the request because we
 		// assume that the uploading user is trusted, so they can upload files of
 		// any size they want.
-		id, err := s.insertFileFromRequest(r, expiration, picoshare.GuestLinkID(""))
+		id, friendlyName, err := s.insertFileFromRequest(r, expiration, picoshare.GuestLinkID(""))
 		if err != nil {
 			if _, ok := errors.AsType[*dbError](err); ok {
 				log.Printf("failed to insert uploaded file into data store: %v", err)
@@ -62,7 +64,7 @@ func (s Server) entryPost() http.HandlerFunc {
 			return
 		}
 
-		respondJSON(w, EntryPostResponse{ID: id.String()})
+		respondJSON(w, EntryPostResponse{ID: id.String(), FriendlyName: string(friendlyName)})
 	}
 }
 
@@ -133,7 +135,7 @@ func (s Server) guestEntryPost() http.HandlerFunc {
 			return
 		}
 
-		id, err := s.insertFileFromRequest(r, expiration, guestLinkID)
+		id, friendlyName, err := s.insertFileFromRequest(r, expiration, guestLinkID)
 		if err != nil {
 			if _, ok := errors.AsType[*dbError](err); ok {
 				log.Printf("failed to insert uploaded file into data store: %v", err)
@@ -146,12 +148,16 @@ func (s Server) guestEntryPost() http.HandlerFunc {
 		}
 
 		if clientAcceptsJson(r) {
-			respondJSON(w, EntryPostResponse{ID: id.String()})
+			respondJSON(w, EntryPostResponse{ID: id.String(), FriendlyName: string(friendlyName)})
 		} else {
 			// If client does not accept JSON, assume this is a command-line client
 			// and return plaintext.
 			w.Header().Set("Content-Type", "text/plain")
-			if _, err := fmt.Fprintf(w, "%s/-%s\r\n", baseURLFromRequest(r), id.String()); err != nil {
+			urlPath := fmt.Sprintf("-%s", id.String())
+			if friendlyName != "" {
+				urlPath = fmt.Sprintf("n/%s", friendlyName)
+			}
+			if _, err := fmt.Fprintf(w, "%s/%s\r\n", baseURLFromRequest(r), urlPath); err != nil {
 				log.Fatalf("failed to write HTTP response: %v", err)
 			}
 		}
@@ -219,12 +225,12 @@ func parseEntryID(s string) (picoshare.EntryID, error) {
 	return picoshare.EntryID(s), nil
 }
 
-func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.ExpirationTime, guestLinkID picoshare.GuestLinkID) (picoshare.EntryID, error) {
+func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.ExpirationTime, guestLinkID picoshare.GuestLinkID) (picoshare.EntryID, picoshare.FriendlyName, error) {
 	// ParseMultipartForm can go above the limit we set, so set a conservative RAM
 	// limit to avoid exhausting RAM on servers with limited resources.
 	multipartMaxMemory := mibToBytes(1)
 	if err := r.ParseMultipartForm(multipartMaxMemory); err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
 	}
 	defer func() {
 		if err := r.MultipartForm.RemoveAll(); err != nil {
@@ -234,31 +240,49 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 
 	reader, metadata, err := r.FormFile("file")
 	if err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
 	}
 
 	fileSize, err := picoshare.FileSizeFromInt64(metadata.Size)
 	if err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
 	}
 
 	filename, err := parse.Filename(metadata.Filename)
 	if err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
+	}
+
+	customFilename := r.FormValue("filename")
+	if strings.TrimSpace(customFilename) != "" {
+		filename, err = parse.Filename(customFilename)
+		if err != nil {
+			return picoshare.EntryID(""), picoshare.FriendlyName(""), err
+		}
 	}
 
 	contentType, err := parseContentType(metadata.Header.Get("Content-Type"))
 	if err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
 	}
 
 	note, err := parse.FileNote(r.FormValue("note"))
 	if err != nil {
-		return picoshare.EntryID(""), err
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), err
 	}
 
 	if guestLinkID != "" && note.Value != nil {
-		return picoshare.EntryID(""), errors.New("guest uploads cannot have file notes")
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), errors.New("guest uploads cannot have file notes")
+	}
+
+	friendlyNameRaw := r.FormValue("friendly_name")
+	var friendlyName picoshare.FriendlyName
+	if friendlyNameRaw != "" {
+		var err error
+		friendlyName, err = parse.FriendlyName(friendlyNameRaw)
+		if err != nil {
+			return picoshare.EntryID(""), picoshare.FriendlyName(""), err
+		}
 	}
 
 	id := generateEntryID()
@@ -277,10 +301,47 @@ func (s Server) insertFileFromRequest(r *http.Request, expiration picoshare.Expi
 		})
 	if err != nil {
 		log.Printf("failed to save entry: %v", err)
-		return picoshare.EntryID(""), dbError{err}
+		return picoshare.EntryID(""), picoshare.FriendlyName(""), dbError{err}
 	}
 
-	return id, nil
+	deleteOld := r.FormValue("delete_old") == "true"
+	if friendlyName != "" {
+		db := s.getDB(r)
+		oldFL, err := db.GetFriendlyLink(friendlyName)
+		exists := true
+		if err != nil {
+			if _, ok := errors.AsType[store.FriendlyLinkNotFoundError](err); ok {
+				exists = false
+			} else {
+				log.Printf("failed to check for existing friendly link: %v", err)
+				// Continue anyway, as the main file upload succeeded
+			}
+		}
+
+		newFL := picoshare.FriendlyLink{
+			FriendlyName:    friendlyName,
+			EntryID:         id,
+			Created:         s.clock.Now(),
+			UrlExpires:      expiration,
+			MaxFileLifetime: picoshare.FileLifetimeInfinite,
+		}
+
+		if exists {
+			if err := db.UpdateFriendlyLink(newFL); err != nil {
+				log.Printf("failed to update friendly link: %v", err)
+			} else if deleteOld {
+				if err := db.DeleteEntry(oldFL.EntryID); err != nil {
+					log.Printf("failed to delete old entry %s: %v", oldFL.EntryID, err)
+				}
+			}
+		} else {
+			if err := db.InsertFriendlyLink(newFL); err != nil {
+				log.Printf("failed to insert friendly link: %v", err)
+			}
+		}
+	}
+
+	return id, friendlyName, nil
 }
 
 func parseContentType(s string) (picoshare.ContentType, error) {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -41,27 +41,36 @@ func (c mockClock) Now() time.Time {
 
 func TestEntryPost(t *testing.T) {
 	for _, tt := range []struct {
-		description string
-		filename    string
-		contents    string
-		expiration  string
-		note        string
-		status      int
+		description    string
+		filename       string
+		customFilename string
+		contents       string
+		expiration     string
+		note           string
+		status         int
 	}{
 		{
-			description: "valid file with no note",
-			filename:    "dummyimage.png",
-			contents:    "dummy bytes",
-			expiration:  "2040-01-01T00:00:00Z",
-			status:      http.StatusOK,
+			description:    "valid file with no note",
+			filename:       "dummyimage.png",
+			contents:       "dummy bytes",
+			expiration:     "2040-01-01T00:00:00Z",
+			status:         http.StatusOK,
 		},
 		{
-			description: "valid file with a note",
-			filename:    "dummyimage.png",
-			contents:    "dummy bytes",
-			note:        "for my homeboy, willy",
-			expiration:  "2040-01-01T00:00:00Z",
-			status:      http.StatusOK,
+			description:    "valid file with a note",
+			filename:       "dummyimage.png",
+			contents:       "dummy bytes",
+			note:           "for my homeboy, willy",
+			expiration:     "2040-01-01T00:00:00Z",
+			status:         http.StatusOK,
+		},
+		{
+			description:    "valid file with a custom filename",
+			filename:       "dummyimage.png",
+			customFilename: "friendly-name.txt",
+			contents:       "dummy bytes",
+			expiration:     "2040-01-01T00:00:00Z",
+			status:         http.StatusOK,
 		},
 		{
 			description: "valid file with a too-long note",
@@ -104,7 +113,7 @@ func TestEntryPost(t *testing.T) {
 			dataStore := test_sqlite.New()
 			s := handlers.New(mockAuthenticator{}, &dataStore, nilSpaceChecker, nilGarbageCollector, handlers.NewClock())
 
-			formData, contentType := createMultipartFormBody(tt.filename, tt.note, bytes.NewBuffer([]byte(tt.contents)))
+			formData, contentType := createMultipartFormBody(tt.filename, tt.customFilename, tt.note, bytes.NewBuffer([]byte(tt.contents)))
 
 			req := httptest.NewRequest(
 				http.MethodPost,
@@ -142,7 +151,12 @@ func TestEntryPost(t *testing.T) {
 				t.Fatalf("failed to get expected entry %v from data store: %v", response.ID, err)
 			}
 
-			if got, want := entry.Filename, picoshare.Filename(tt.filename); got != want {
+			expectedFilename := tt.filename
+			if tt.customFilename != "" {
+				expectedFilename = tt.customFilename
+			}
+
+			if got, want := entry.Filename, picoshare.Filename(expectedFilename); got != want {
 				t.Errorf("filename=%v, want=%v", got, want)
 			}
 
@@ -579,7 +593,7 @@ func TestGuestUpload(t *testing.T) {
 
 			filename := "dummyimage.png"
 			contents := "dummy bytes"
-			formData, contentType := createMultipartFormBody(filename, tt.note, strings.NewReader(contents))
+			formData, contentType := createMultipartFormBody(filename, "", tt.note, strings.NewReader(contents))
 
 			req := httptest.NewRequest(http.MethodPost, tt.url, formData)
 			req.Header.Add("Content-Type", contentType)
@@ -704,7 +718,7 @@ func TestGuestUploadAcceptHeader(t *testing.T) {
 
 			filename := "dummyimage.png"
 			contents := "dummy bytes"
-			formData, contentType := createMultipartFormBody(filename, "", strings.NewReader(contents))
+			formData, contentType := createMultipartFormBody(filename, "", "", strings.NewReader(contents))
 
 			req := httptest.NewRequest(
 				http.MethodPost,
@@ -756,7 +770,7 @@ func TestGuestUploadAcceptHeader(t *testing.T) {
 	}
 }
 
-func createMultipartFormBody(filename, note string, r io.Reader) (io.Reader, string) {
+func createMultipartFormBody(filename, customFilename, note string, r io.Reader) (io.Reader, string) {
 	var b bytes.Buffer
 	bw := bufio.NewWriter(&b)
 	mw := multipart.NewWriter(bw)
@@ -766,6 +780,14 @@ func createMultipartFormBody(filename, note string, r io.Reader) (io.Reader, str
 		panic(err)
 	}
 	io.Copy(f, r)
+
+	if customFilename != "" {
+		fn, err := mw.CreateFormField("filename")
+		if err != nil {
+			panic(err)
+		}
+		fn.Write([]byte(customFilename))
+	}
 
 	nf, err := mw.CreateFormField("note")
 	if err != nil {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -50,19 +50,19 @@ func TestEntryPost(t *testing.T) {
 		status         int
 	}{
 		{
-			description:    "valid file with no note",
-			filename:       "dummyimage.png",
-			contents:       "dummy bytes",
-			expiration:     "2040-01-01T00:00:00Z",
-			status:         http.StatusOK,
+			description: "valid file with no note",
+			filename:    "dummyimage.png",
+			contents:    "dummy bytes",
+			expiration:  "2040-01-01T00:00:00Z",
+			status:      http.StatusOK,
 		},
 		{
-			description:    "valid file with a note",
-			filename:       "dummyimage.png",
-			contents:       "dummy bytes",
-			note:           "for my homeboy, willy",
-			expiration:     "2040-01-01T00:00:00Z",
-			status:         http.StatusOK,
+			description: "valid file with a note",
+			filename:    "dummyimage.png",
+			contents:    "dummy bytes",
+			note:        "for my homeboy, willy",
+			expiration:  "2040-01-01T00:00:00Z",
+			status:      http.StatusOK,
 		},
 		{
 			description:    "valid file with a custom filename",

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -171,8 +171,8 @@ func (s Server) friendlyLinkIndexGet() http.HandlerFunc {
 			commonProps
 			FriendlyLinks []picoshare.FriendlyLink
 		}{
-			commonProps: makeCommonProps("PicoShare - Friendly Links", r.Context()),
-			FriendlyLinks:  links,
+			commonProps:   makeCommonProps("PicoShare - Friendly Links", r.Context()),
+			FriendlyLinks: links,
 		}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -116,6 +116,70 @@ func (s Server) guestLinkIndexGet() http.HandlerFunc {
 	}
 }
 
+func (s Server) friendlyLinkIndexGet() http.HandlerFunc {
+	fns := template.FuncMap{
+		"formatDate": func(t time.Time) string {
+			return t.Format(time.DateOnly)
+		},
+		"formatSizeLimit": func(limit picoshare.GuestUploadMaxFileBytes) string {
+			if limit == picoshare.GuestUploadUnlimitedFileSize {
+				return "Unlimited"
+			}
+			b := uint64(*limit)
+			const unit = 1024
+
+			if b < unit {
+				return fmt.Sprintf("%d B", b)
+			}
+			div, exp := int64(unit), 0
+			for n := b / unit; n >= unit; n /= unit {
+				div *= unit
+				exp++
+			}
+			return fmt.Sprintf("%.2f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+		},
+		"formatCountLimit": func(limit picoshare.GuestUploadCountLimit) string {
+			if limit == picoshare.GuestUploadUnlimitedFileUploads {
+				return "Unlimited"
+			}
+			return fmt.Sprintf("%d", int(*limit))
+		},
+		"formatExpiration": func(et picoshare.ExpirationTime) string {
+			if et == picoshare.NeverExpire {
+				return "Never"
+			}
+			t := time.Time(et)
+			delta := t.Sub(s.clock.Now())
+			suffix := ""
+			if delta.Seconds() < 0 {
+				suffix = " ago"
+			}
+			return fmt.Sprintf("%s (%.0f days%s)", t.Format(time.DateOnly), math.Abs(delta.Hours())/24, suffix)
+		},
+	}
+
+	t := parseTemplatesWithFuncs(fns, "templates/pages/friendly-link-index.html")
+	return func(w http.ResponseWriter, r *http.Request) {
+		links, err := s.getDB(r).GetFriendlyLinks()
+		if err != nil {
+			log.Printf("failed to retrieve friendly links: %v", err)
+			http.Error(w, "Failed to retrieve friendly links", http.StatusInternalServerError)
+			return
+		}
+
+		if err := t.Execute(w, struct {
+			commonProps
+			FriendlyLinks []picoshare.FriendlyLink
+		}{
+			commonProps: makeCommonProps("PicoShare - Friendly Links", r.Context()),
+			FriendlyLinks:  links,
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
 func (s Server) guestLinksNewGet() http.HandlerFunc {
 	fns := template.FuncMap{
 		"formatExpiration": func(t time.Time) string {
@@ -531,10 +595,12 @@ func (s Server) uploadGet() http.HandlerFunc {
 			commonProps
 			ExpirationOptions []expirationOption
 			MaxNoteLength     int
+			MaxFilenameLength int
 			GuestLinkMetadata picoshare.GuestLink
 		}{
 			commonProps:       makeCommonProps("PicoShare - Upload", r.Context()),
 			MaxNoteLength:     parse.MaxFileNoteBytes,
+			MaxFilenameLength: parse.MaxFilenameBytes,
 			ExpirationOptions: expirationOptions,
 		}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -641,9 +707,11 @@ func (s Server) guestUploadGet() http.HandlerFunc {
 		if err := t.Execute(w, struct {
 			commonProps
 			ExpirationOptions []expirationOption
+			MaxFilenameLength int
 			GuestLinkMetadata picoshare.GuestLink
 		}{
 			commonProps:       makeCommonProps("PicoShare - Upload", r.Context()),
+			MaxFilenameLength: parse.MaxFilenameBytes,
 			ExpirationOptions: expirationOptions,
 			GuestLinkMetadata: gl,
 		}); err != nil {

--- a/picoshare/friendly_link.go
+++ b/picoshare/friendly_link.go
@@ -1,0 +1,17 @@
+package picoshare
+
+import (
+	"time"
+)
+
+type FriendlyLink struct {
+	FriendlyName    FriendlyName
+	EntryID         EntryID
+	Label           GuestLinkLabel
+	Created         time.Time
+	UrlExpires      ExpirationTime
+	MaxFileLifetime FileLifetime
+	MaxFileBytes    GuestUploadMaxFileBytes
+	MaxFileUploads  GuestUploadCountLimit
+	IsDisabled      bool
+}

--- a/picoshare/picoshare.go
+++ b/picoshare/picoshare.go
@@ -8,6 +8,7 @@ import (
 type (
 	EntryID        string
 	Filename       string
+	FriendlyName   string
 	ContentType    string
 	ExpirationTime time.Time
 

--- a/store/sqlite/friendly_links.go
+++ b/store/sqlite/friendly_links.go
@@ -1,0 +1,189 @@
+package sqlite
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/mtlynch/picoshare/picoshare"
+	"github.com/mtlynch/picoshare/store"
+)
+
+func (s Store) GetFriendlyLink(name picoshare.FriendlyName) (picoshare.FriendlyLink, error) {
+	row := s.ctx.QueryRow(`
+		SELECT
+			friendly_name,
+			id,
+			label,
+			max_file_bytes,
+			max_file_uploads,
+			creation_time,
+			url_expiration_time,
+			file_expiration_time,
+			is_disabled
+		FROM
+			friendly_links
+		WHERE
+			friendly_name=:name`, sql.Named("name", name))
+
+	return friendlyLinkFromRow(row, name)
+}
+
+func (s Store) GetFriendlyLinks() ([]picoshare.FriendlyLink, error) {
+	rows, err := s.ctx.Query(`
+		SELECT
+			friendly_name,
+			id,
+			label,
+			max_file_bytes,
+			max_file_uploads,
+			creation_time,
+			url_expiration_time,
+			file_expiration_time,
+			is_disabled
+		FROM
+			friendly_links`)
+	if err != nil {
+		return []picoshare.FriendlyLink{}, err
+	}
+
+	fls := []picoshare.FriendlyLink{}
+	for rows.Next() {
+		fl, err := friendlyLinkFromRow(rows, "")
+		if err != nil {
+			return []picoshare.FriendlyLink{}, err
+		}
+
+		fls = append(fls, fl)
+	}
+
+	return fls, nil
+}
+
+func (s *Store) InsertFriendlyLink(fl picoshare.FriendlyLink) error {
+	log.Printf("saving new friendly link %s -> %s", fl.FriendlyName, fl.EntryID)
+
+	if _, err := s.ctx.Exec(`
+	INSERT INTO friendly_links
+		(
+			friendly_name,
+			id,
+			label,
+			max_file_bytes,
+			max_file_uploads,
+			creation_time,
+			url_expiration_time,
+			file_expiration_time,
+			is_disabled
+		)
+		VALUES (:friendly_name, :id, :label, :max_file_bytes, :max_file_uploads, :creation_time, :url_expiration_time, :file_expiration_time, :is_disabled)
+	`,
+		sql.Named("friendly_name", fl.FriendlyName),
+		sql.Named("id", fl.EntryID),
+		sql.Named("label", fl.Label),
+		sql.Named("max_file_bytes", fl.MaxFileBytes),
+		sql.Named("max_file_uploads", fl.MaxFileUploads),
+		sql.Named("creation_time", formatTime(fl.Created)),
+		sql.Named("url_expiration_time", formatExpirationTime(fl.UrlExpires)),
+		sql.Named("file_expiration_time", formatFileLifetime(fl.MaxFileLifetime)),
+		sql.Named("is_disabled", fl.IsDisabled)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) UpdateFriendlyLink(fl picoshare.FriendlyLink) error {
+	log.Printf("updating friendly link %s -> %s", fl.FriendlyName, fl.EntryID)
+
+	if _, err := s.ctx.Exec(`
+	UPDATE friendly_links
+	SET
+		id = :id,
+		label = :label,
+		max_file_bytes = :max_file_bytes,
+		max_file_uploads = :max_file_uploads,
+		url_expiration_time = :url_expiration_time,
+		file_expiration_time = :file_expiration_time,
+		is_disabled = :is_disabled
+	WHERE
+		friendly_name = :friendly_name
+	`,
+		sql.Named("friendly_name", fl.FriendlyName),
+		sql.Named("id", fl.EntryID),
+		sql.Named("label", fl.Label),
+		sql.Named("max_file_bytes", fl.MaxFileBytes),
+		sql.Named("max_file_uploads", fl.MaxFileUploads),
+		sql.Named("url_expiration_time", formatExpirationTime(fl.UrlExpires)),
+		sql.Named("file_expiration_time", formatFileLifetime(fl.MaxFileLifetime)),
+		sql.Named("is_disabled", fl.IsDisabled)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) DeleteFriendlyLink(name picoshare.FriendlyName) error {
+	log.Printf("deleting friendly link %s", name)
+
+	if _, err := s.ctx.Exec(`
+	DELETE FROM
+		friendly_links
+	WHERE
+		friendly_name=:name`, sql.Named("name", name)); err != nil {
+		log.Printf("deleting %s from friendly_links table failed: %v", name, err)
+		return err
+	}
+
+	return nil
+}
+
+func friendlyLinkFromRow(row rowScanner, name picoshare.FriendlyName) (picoshare.FriendlyLink, error) {
+	var friendlyName picoshare.FriendlyName
+	var id picoshare.EntryID
+	var label picoshare.GuestLinkLabel
+	var maxFileBytes picoshare.GuestUploadMaxFileBytes
+	var maxFileUploads picoshare.GuestUploadCountLimit
+	var creationTimeRaw string
+	var urlExpirationTimeRaw string
+	var fileLifetimeRaw *string
+	var isDisabled bool
+
+	err := row.Scan(&friendlyName, &id, &label, &maxFileBytes, &maxFileUploads, &creationTimeRaw, &urlExpirationTimeRaw, &fileLifetimeRaw, &isDisabled)
+	if err == sql.ErrNoRows {
+		return picoshare.FriendlyLink{}, store.FriendlyLinkNotFoundError{Name: string(name)}
+	} else if err != nil {
+		return picoshare.FriendlyLink{}, err
+	}
+
+	ct, err := parseDatetime(creationTimeRaw)
+	if err != nil {
+		return picoshare.FriendlyLink{}, err
+	}
+
+	uet, err := parseDatetime(urlExpirationTimeRaw)
+	if err != nil {
+		return picoshare.FriendlyLink{}, err
+	}
+
+	var fileLifetime picoshare.FileLifetime
+	if fileLifetimeRaw == nil {
+		fileLifetime = picoshare.FileLifetimeInfinite
+	} else {
+		fileLifetime, err = parseFileLifetime(*fileLifetimeRaw)
+		if err != nil {
+			return picoshare.FriendlyLink{}, err
+		}
+	}
+
+	return picoshare.FriendlyLink{
+		FriendlyName:    friendlyName,
+		EntryID:         id,
+		Label:           label,
+		Created:         ct,
+		UrlExpires:      picoshare.ExpirationTime(uet),
+		MaxFileLifetime: fileLifetime,
+		MaxFileBytes:    maxFileBytes,
+		MaxFileUploads:  maxFileUploads,
+		IsDisabled:      isDisabled,
+	}, nil
+}

--- a/store/sqlite/migrations/016-create-friendly-links-table.sql
+++ b/store/sqlite/migrations/016-create-friendly-links-table.sql
@@ -1,0 +1,26 @@
+CREATE TABLE friendly_links (
+    friendly_name TEXT PRIMARY KEY,
+    id TEXT NOT NULL,
+    label TEXT CHECK (
+        label IS NULL OR length(label) <= 200
+    ),
+    max_file_bytes INTEGER CHECK (
+        max_file_bytes IS NULL OR max_file_bytes > 0
+    ),
+    max_file_uploads INTEGER CHECK (
+        max_file_uploads IS NULL OR max_file_uploads > 0
+    ),
+    creation_time TEXT NOT NULL CHECK (
+        datetime(creation_time) IS NOT NULL
+        AND datetime(creation_time) >= datetime('2022-02-20')
+    ),
+    url_expiration_time TEXT CHECK (
+        url_expiration_time IS NULL OR (
+            datetime(url_expiration_time) IS NOT NULL
+            AND datetime(url_expiration_time) >= datetime('2022-02-20')
+        )
+    ),
+    file_expiration_time TEXT,
+    is_disabled INTEGER NOT NULL CHECK (is_disabled IN (0, 1)) DEFAULT 0,
+    FOREIGN KEY (id) REFERENCES entries (id) ON DELETE CASCADE
+) STRICT;

--- a/store/store.go
+++ b/store/store.go
@@ -23,3 +23,12 @@ type GuestLinkNotFoundError struct {
 func (f GuestLinkNotFoundError) Error() string {
 	return fmt.Sprintf("Could not find guest link with ID %v", f.ID)
 }
+
+// FriendlyLinkNotFoundError occurs when no friendly link exists with the given name.
+type FriendlyLinkNotFoundError struct {
+	Name string
+}
+
+func (f FriendlyLinkNotFoundError) Error() string {
+	return fmt.Sprintf("Could not find friendly link with name %v", f.Name)
+}


### PR DESCRIPTION
As discussed in https://github.com/mtlynch/picoshare/discussions/772

This implementation introduces the following:

1. an option on the Upload form to define a friendly link name
2. an option on the upload form to delete an existing file if it is linked to the friendly name (to avoid having orphan files)
3. a new table in the database which holds the friendly names and id linkage
4. a Friendly links page to show what is currently defined and enable/disable the friendly links as per the guest links options
5. add in the API the option to upload via curl and define the friendly name and if existing files should be deleted (as per 1 and 2 above) - curl -F "file=@testfile.txt" "http://localhost:4001/api/guest/iJkSiJAjkdb575Zc?friendly_name=myfriendlyname&delete_old=true"

Note I am not a developer and this was 100% Gemini coded, so I won't be offended if you discard this completely.  However, in my testing it works well.