### PR TITLE
Fix version display on /information page

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -5,8 +5,13 @@ import (
 	"time"
 )
 
-// Version is set by ldflags at build time via -X 'github.com/mtlynch/picoshare/build.Version=...'
-var Version string
+func Version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return info.Main.Version
+}
 
 func Time() time.Time {
 	v := buildSetting("vcs.time")

--- a/e2e/system-info.spec.ts
+++ b/e2e/system-info.spec.ts
@@ -7,4 +7,5 @@ test("views system info", async ({ page }) => {
   await page.getByRole("menuitem", { name: "System" }).hover();
   await page.getByRole("menuitem", { name: "Information" }).click();
   await expect(page).toHaveURL("/information");
+  await expect(page.locator(".content")).toContainText(/Version:\s+\S+/);
 });

--- a/handlers/views.go
+++ b/handlers/views.go
@@ -727,7 +727,7 @@ func (s Server) systemInformationGet() http.HandlerFunc {
 			UsedBytes:         spaceUsage.FileSystemUsedBytes,
 			TotalBytes:        spaceUsage.FileSystemTotalBytes,
 			BuildTime:         build.Time(),
-			Version:           build.Version,
+			Version:           build.Version(),
 			Revision:          build.Revision(),
 		}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
3248b5d5e0d0f0307cfd87003f15e696f9479463 and 68ccda3bc05d81631697129742789db07c1dc20b switched the way we populate version information, but they accidentally caused a regression on the /information page.

Fixes #774