### PR TITLE
Fix version tagging in CI to match new version style

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
           name: Build binaries
           command: |
             set -eux
-            if [[ "${CIRCLE_TAG-''}" =~ ^[0-9]+(\.[0-9]+){2}.*  || \
+            if [[ "${CIRCLE_TAG-''}" =~ ^v[0-9]+(\.[0-9]+){2}.*  || \
                   "${CIRCLE_BRANCH}" == 'master' ]]; then
               readonly BUILD_TARGETS='linux/arm/v7,linux/arm64,linux/amd64'
             else
@@ -150,8 +150,8 @@ jobs:
           command: |
             set -eux
             VERSION=''
-            if [[ "${CIRCLE_TAG-''}" =~ ^[0-9]+(\.[0-9]+){2}.* ]]; then
-              VERSION="${CIRCLE_TAG}"
+            if [[ "${CIRCLE_TAG-''}" =~ ^v[0-9]+(\.[0-9]+){2}.* ]]; then
+              VERSION="${CIRCLE_TAG#v}"
             elif [[ "${CIRCLE_BRANCH}" == 'master' ]]; then
               VERSION="${CIRCLE_SHA1}"
             fi
@@ -281,7 +281,7 @@ workflows:
             - package_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+){2}/
+              only: /v[0-9]+(\.[0-9]+){2}/
             branches:
               ignore: /.*/
       - publish_docker_images:
@@ -289,7 +289,7 @@ workflows:
             - package_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+){2}/
+              only: /v[0-9]+(\.[0-9]+){2}/
             branches:
               ignore: /.*/
       - deploy:


### PR DESCRIPTION
As of v1.5.3, PicoShare versions have a v prefix, so this updates our CircleCI config to match.

Fixes #777