### PR TITLE
docs: add third-party clients section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ PicoShare is easy to deploy to cloud hosting platforms:
 
 - [fly.io](docs/deployment/fly.io.md)
 
+## Third-party clients
+
+These clients are built and maintained by third parties, not by the PicoShare project:
+
+- [picaroa](https://www.picaroa.app) - Native iOS client for PicoShare
+
 ## Tips and tricks
 
 ### Reclaiming reserved database space


### PR DESCRIPTION
Hi Michael, 

thanks for PicoShare — I've been running it in my homelab for a while and really appreciate how simple it is to host. We have been in contact recently.

As you know, I built a native iOS client for it called picaroa (upload via the iOS share sheet, manage files and expiration, copy share links on the go). 

This PR adds a short "Third-party clients" section to the README so iOS users can discover it.

Full disclosure: I'm the developer of the app, and the app itself is not open source. Totally understand if you'd prefer to keep the README focused — feel free to close this in that case. Happy to adjust wording or placement.

Warm regards
Sven